### PR TITLE
Async implementations of slice and response

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,12 +35,6 @@ SOFTWARE.
   <url>https://github.com/artipie/http</url>
   <dependencies>
     <dependency>
-      <groupId>org.takes</groupId>
-      <artifactId>takes</artifactId>
-      <version>1.19</version>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>org.cactoos</groupId>
       <artifactId>cactoos</artifactId>
     </dependency>

--- a/src/main/java/com/artipie/http/async/AsyncSlice.java
+++ b/src/main/java/com/artipie/http/async/AsyncSlice.java
@@ -54,7 +54,7 @@ public final class AsyncSlice implements Slice {
      * Ctor.
      * @param slice Async slice.
      */
-    AsyncSlice(final CompletionStage<Slice> slice) {
+    public AsyncSlice(final CompletionStage<Slice> slice) {
         this.slice = slice;
     }
 

--- a/src/main/java/com/artipie/http/async/AsyncSlice.java
+++ b/src/main/java/com/artipie/http/async/AsyncSlice.java
@@ -1,0 +1,69 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.artipie.http.async;
+
+import com.artipie.http.Response;
+import com.artipie.http.Slice;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Flow;
+
+/**
+ * Asynchronous {@link Slice} implementation.
+ * <p>
+ * This slice encapsulates {@link CompletionStage} of {@link Slice}
+ * and returns {@link RsAsync} with completion stage mapping.
+ * </p>
+ * @since 0.4
+ * @todo #41:30min Add unit tests for AsyncSlice and RsAsync.
+ *  Tests should verify the positive case, when slice and response
+ *  completes normally; And exceptional behavior, when 500 error should be
+ *  sent to connection.
+ */
+public final class AsyncSlice implements Slice {
+
+    /**
+     * Async slice.
+     */
+    private final CompletionStage<Slice> slice;
+
+    /**
+     * Ctor.
+     * @param slice Async slice.
+     */
+    AsyncSlice(final CompletionStage<Slice> slice) {
+        this.slice = slice;
+    }
+
+    @Override
+    public Response response(final String line,
+        final Iterable<Map.Entry<String, String>> headers,
+        final Flow.Publisher<ByteBuffer> body) {
+        return new RsAsync(
+            this.slice.thenApply(target -> target.response(line, headers, body))
+        );
+    }
+}

--- a/src/main/java/com/artipie/http/async/RsAsync.java
+++ b/src/main/java/com/artipie/http/async/RsAsync.java
@@ -52,7 +52,7 @@ public final class RsAsync implements Response {
      * Ctor.
      * @param rsp Response
      */
-    RsAsync(final CompletionStage<Response> rsp) {
+    public RsAsync(final CompletionStage<Response> rsp) {
         this.rsp = rsp;
     }
 

--- a/src/main/java/com/artipie/http/async/RsAsync.java
+++ b/src/main/java/com/artipie/http/async/RsAsync.java
@@ -1,0 +1,69 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.artipie.http.async;
+
+import com.artipie.http.Connection;
+import com.artipie.http.Response;
+import com.artipie.http.rs.RsWithBody;
+import com.artipie.http.rs.RsWithStatus;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Asynchronous {@link Response} implementation.
+ * <p>
+ * Response which send itself to connection only when
+ * underlying {@link CompletionStage} with response is ready.
+ * If completion stage fails, this decorator sends 500 status code with
+ * message text as a body.
+ * </p>
+ * @since 0.4
+ */
+public final class RsAsync implements Response {
+
+    /**
+     * Async response.
+     */
+    private final CompletionStage<Response> rsp;
+
+    /**
+     * Ctor.
+     * @param rsp Response
+     */
+    RsAsync(final CompletionStage<Response> rsp) {
+        this.rsp = rsp;
+    }
+
+    @Override
+    public void send(final Connection con) {
+        this.rsp.exceptionally(
+            err -> new RsWithStatus(
+                new RsWithBody(err.getMessage(), StandardCharsets.UTF_8),
+                // @checkstyle MagicNumberCheck (1 line)
+                500
+            )
+        ).thenAccept(target -> target.send(con));
+    }
+}

--- a/src/main/java/com/artipie/http/async/package-info.java
+++ b/src/main/java/com/artipie/http/async/package-info.java
@@ -1,0 +1,30 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Async implementations of {@link Slice}, {@link Response}, etc.
+ * @since 0.4
+ */
+package com.artipie.http.async;
+


### PR DESCRIPTION
#41 - added async implementations for `Slice` and `Response` based on `CompletionStage`, returning 500 error in case of unhandled exception in `CompletionStage`.