### PR TITLE
Split improvements

### DIFF
--- a/src/main/java/com/artipie/http/stream/ByteByByteSplit.java
+++ b/src/main/java/com/artipie/http/stream/ByteByByteSplit.java
@@ -173,7 +173,7 @@ public final class ByteByByteSplit implements Processor<ByteBuffer, Publisher<By
         for (final byte each : bytes) {
             final boolean eviction = this.ring.isAtFullCapacity();
             if (eviction) {
-                final Byte last = this.ring.get(this.delim.length - 1);
+                final Byte last = this.ring.get(0);
                 current.put(last);
             }
             this.ring.add(each);

--- a/src/test/java/com/artipie/http/stream/ByteByByteSplitTest.java
+++ b/src/test/java/com/artipie/http/stream/ByteByByteSplitTest.java
@@ -49,7 +49,6 @@ public final class ByteByByteSplitTest {
         );
     }
 
-
     @Test
     public void severalCharSplitWorks() {
         final ByteByByteSplit split = new ByteByByteSplit("__".getBytes());

--- a/src/test/java/com/artipie/http/stream/ByteByByteSplitTest.java
+++ b/src/test/java/com/artipie/http/stream/ByteByByteSplitTest.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.Test;
  * @since 0.4
  * @checkstyle MagicNumberCheck (500 lines)
  */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class ByteByByteSplitTest {
 
     @Test
@@ -85,7 +86,7 @@ public final class ByteByByteSplitTest {
         );
     }
 
-    private Flowable<ByteBuffer> buffersOfOneByteFlow(String str) {
+    private Flowable<ByteBuffer> buffersOfOneByteFlow(final String str) {
         return Flowable.fromArray(
             Arrays.stream(
                 ArrayUtils.toObject(str.getBytes())


### PR DESCRIPTION
For now, stream splitter does now work correctly with delimiters of size 2 or more. This PR fixes the problem