### PR TITLE
#86 - Mark & reset buffers in RsHasBody

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,12 @@ SOFTWARE.
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>${junit-platform.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.llorllale</groupId>
       <artifactId>cactoos-matchers</artifactId>
       <version>0.18</version>

--- a/src/main/java/com/artipie/http/hm/RsHasBody.java
+++ b/src/main/java/com/artipie/http/hm/RsHasBody.java
@@ -116,16 +116,22 @@ public final class RsHasBody extends TypeSafeMatcher<Response> {
                         .stream()
                         .reduce(
                             (left, right) -> {
+                                left.mark();
+                                right.mark();
                                 final ByteBuffer concat = ByteBuffer.allocate(
                                     left.remaining() + right.remaining()
                                 ).put(left).put(right);
+                                left.reset();
+                                right.reset();
                                 concat.flip();
                                 return concat;
                             }
                         )
                         .orElse(ByteBuffer.allocate(0));
                     final byte[] bytes = new byte[buffer.remaining()];
+                    buffer.mark();
                     buffer.get(bytes);
+                    buffer.reset();
                     this.container.set(bytes);
                     return null;
                 }

--- a/src/test/java/com/artipie/http/hm/RsHasBodyTest.java
+++ b/src/test/java/com/artipie/http/hm/RsHasBodyTest.java
@@ -25,12 +25,17 @@ package com.artipie.http.hm;
 
 import com.artipie.http.Response;
 import com.artipie.http.rs.RsStatus;
+import com.artipie.http.rs.RsWithBody;
 import io.reactivex.Flowable;
 import java.nio.ByteBuffer;
 import java.util.Collections;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Tests for {@link RsHasBody}.
@@ -71,4 +76,23 @@ class RsHasBodyTest {
         );
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {"data", "chunk1,chunk2"})
+    void shouldMatchResponseTwice(final String chunks) {
+        final String[] elements = chunks.split(",");
+        final byte[] data = String.join("", elements).getBytes();
+        final Response response = new RsWithBody(
+            Flowable.fromIterable(
+                Stream.of(elements)
+                    .map(String::getBytes)
+                    .map(ByteBuffer::wrap)
+                    .collect(Collectors.toList())
+            )
+        );
+        new RsHasBody(data).matches(response);
+        MatcherAssert.assertThat(
+            new RsHasBody(data).matches(response),
+            new IsEqual<>(true)
+        );
+    }
 }


### PR DESCRIPTION
Closes issue #86 
Added mark() and reset() calls to RsHasBody, so buffers remain unchanged after matching