### PR TITLE
Not found response created

### DIFF
--- a/src/main/java/com/artipie/http/Response.java
+++ b/src/main/java/com/artipie/http/Response.java
@@ -52,7 +52,9 @@ public interface Response {
      */
     Response NOT_FOUND = con -> con.accept(
         RsStatus.NOT_FOUND,
-        new ListOf<>(new MapEntry<>("Content-Type", "application/json")),
+        new ListOf<java.util.Map.Entry<String, String>>(
+            new MapEntry<>("Content-Type", "application/json")
+        ),
         Flowable.fromArray(ByteBuffer.wrap("{\"error\" : \"not found\"}".getBytes()))
     );
 

--- a/src/main/java/com/artipie/http/Response.java
+++ b/src/main/java/com/artipie/http/Response.java
@@ -25,8 +25,11 @@ package com.artipie.http;
 
 import com.artipie.http.rs.RsStatus;
 import io.reactivex.Flowable;
+import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.concurrent.CompletionStage;
+import org.cactoos.list.ListOf;
+import org.cactoos.map.MapEntry;
 
 /**
  * HTTP response.
@@ -42,6 +45,15 @@ public interface Response {
         RsStatus.OK,
         Collections.emptyList(),
         Flowable.empty()
+    );
+
+    /**
+     * Not found response.
+     */
+    Response NOT_FOUND = con -> con.accept(
+        RsStatus.NOT_FOUND,
+        new ListOf<>(new MapEntry<>("Content-Type", "application/json")),
+        Flowable.fromArray(ByteBuffer.wrap("{\"error\" : \"not found\"}".getBytes()))
     );
 
     /**

--- a/src/main/java/com/artipie/http/rs/RsWithBody.java
+++ b/src/main/java/com/artipie/http/rs/RsWithBody.java
@@ -77,7 +77,7 @@ public final class RsWithBody implements Response {
      * @param buf Buffer body
      */
     public RsWithBody(final ByteBuffer buf) {
-        this(Response.EMPTY, buf);
+        this(StandardRs.EMPTY, buf);
     }
 
     /**
@@ -94,7 +94,7 @@ public final class RsWithBody implements Response {
      * @param body Publisher
      */
     public RsWithBody(final Publisher<ByteBuffer> body) {
-        this(Response.EMPTY, body);
+        this(StandardRs.EMPTY, body);
     }
 
     /**

--- a/src/main/java/com/artipie/http/rs/RsWithStatus.java
+++ b/src/main/java/com/artipie/http/rs/RsWithStatus.java
@@ -52,7 +52,7 @@ public final class RsWithStatus implements Response {
      * @param status Status code
      */
     public RsWithStatus(final RsStatus status) {
-        this(Response.EMPTY, status);
+        this(StandardRs.EMPTY, status);
     }
 
     /**

--- a/src/main/java/com/artipie/http/rs/StandardRs.java
+++ b/src/main/java/com/artipie/http/rs/StandardRs.java
@@ -25,7 +25,9 @@ package com.artipie.http.rs;
 
 import com.artipie.http.Connection;
 import com.artipie.http.Response;
+import io.reactivex.Flowable;
 import java.nio.ByteBuffer;
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.CompletionStage;
 import org.cactoos.list.ListOf;
@@ -39,7 +41,7 @@ public enum StandardRs implements Response {
     /**
      * Empty response.
      */
-    EMPTY(new RsWithStatus(RsStatus.OK)),
+    EMPTY(con -> con.accept(RsStatus.OK, Collections.emptyList(), Flowable.empty())),
 
     /**
      * Not found response.


### PR DESCRIPTION
Created `Response#NOT_FOUND`, this object will help as get rid of utility class in npm-proxy-adapter (https://github.com/artipie/npm-proxy-adapter/pull/1)