### PR TITLE
make it async so it'd be more stable for even loop systems

### DIFF
--- a/src/main/java/com/artipie/http/slice/SliceDownload.java
+++ b/src/main/java/com/artipie/http/slice/SliceDownload.java
@@ -85,15 +85,15 @@ public final class SliceDownload implements Slice {
         final Publisher<ByteBuffer> body) {
         return new AsyncResponse(
             CompletableFuture.supplyAsync(() -> new RequestLineFrom(line).uri().getPath())
-                .thenApply(this.transform)
-                .thenCompose(
+                .thenApplyAsync(this.transform)
+                .thenComposeAsync(
                     key -> this.storage.exists(key).thenCompose(
                         // @checkstyle ReturnCountCheck (10 lines)
                         exist -> {
                             if (exist) {
                                 return this.storage.value(key)
-                                    .thenApply(RsWithBody::new)
-                                    .thenApply(rsp -> new RsWithStatus(rsp, RsStatus.OK));
+                                    .thenApplyAsync(RsWithBody::new)
+                                    .thenApplyAsync(rsp -> new RsWithStatus(rsp, RsStatus.OK));
                             } else {
                                 return CompletableFuture.completedFuture(
                                     new RsWithStatus(

--- a/src/main/java/com/artipie/http/slice/SliceDownload.java
+++ b/src/main/java/com/artipie/http/slice/SliceDownload.java
@@ -92,8 +92,8 @@ public final class SliceDownload implements Slice {
                         exist -> {
                             if (exist) {
                                 return this.storage.value(key)
-                                    .thenApplyAsync(RsWithBody::new)
-                                    .thenApplyAsync(rsp -> new RsWithStatus(rsp, RsStatus.OK));
+                                    .thenApply(RsWithBody::new)
+                                    .thenApply(rsp -> new RsWithStatus(rsp, RsStatus.OK));
                             } else {
                                 return CompletableFuture.completedFuture(
                                     new RsWithStatus(

--- a/src/main/java/com/artipie/http/slice/SliceUpload.java
+++ b/src/main/java/com/artipie/http/slice/SliceUpload.java
@@ -79,9 +79,9 @@ public final class SliceUpload implements Slice {
         final Publisher<ByteBuffer> body) {
         return new AsyncResponse(
             CompletableFuture.supplyAsync(() -> new RequestLineFrom(line).uri().getPath())
-                .thenApply(this.transform)
-                .thenCompose(key -> this.storage.save(key, new ContentWithSize(body, headers)))
-                .thenApply(rsp -> new RsWithStatus(RsStatus.CREATED))
+                .thenApplyAsync(this.transform)
+                .thenComposeAsync(key -> this.storage.save(key, new ContentWithSize(body, headers)))
+                .thenApplyAsync(rsp -> new RsWithStatus(RsStatus.CREATED))
         );
     }
 }

--- a/src/main/java/com/artipie/http/slice/SliceUpload.java
+++ b/src/main/java/com/artipie/http/slice/SliceUpload.java
@@ -81,7 +81,7 @@ public final class SliceUpload implements Slice {
             CompletableFuture.supplyAsync(() -> new RequestLineFrom(line).uri().getPath())
                 .thenApplyAsync(this.transform)
                 .thenComposeAsync(key -> this.storage.save(key, new ContentWithSize(body, headers)))
-                .thenApplyAsync(rsp -> new RsWithStatus(RsStatus.CREATED))
+                .thenApply(rsp -> new RsWithStatus(RsStatus.CREATED))
         );
     }
 }


### PR DESCRIPTION
Make sliceUpload and sliceDownload async so it'd be more stable for even loop systems, resolves #125 