### PR TITLE
#135 - Var args constructors in headers classes

### DIFF
--- a/src/main/java/com/artipie/http/Headers.java
+++ b/src/main/java/com/artipie/http/Headers.java
@@ -23,12 +23,13 @@
  */
 package com.artipie.http;
 
+import com.artipie.http.rs.Header;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Spliterator;
 import java.util.function.Consumer;
-import org.cactoos.map.MapEntry;
 
 /**
  * HTTP request headers.
@@ -62,7 +63,17 @@ public interface Headers extends Iterable<Map.Entry<String, String>> {
          * @param value Header value.
          */
         public From(final String name, final String value) {
-            this(Collections.singleton(new MapEntry<>(name, value)));
+            this(Collections.singleton(new Header(name, value)));
+        }
+
+        /**
+         * Ctor.
+         *
+         * @param origin Origin headers.
+         */
+        @SafeVarargs
+        public From(final Map.Entry<String, String>... origin) {
+            this(Arrays.asList(origin));
         }
 
         /**

--- a/src/main/java/com/artipie/http/hm/RsHasHeaders.java
+++ b/src/main/java/com/artipie/http/hm/RsHasHeaders.java
@@ -27,6 +27,7 @@ package com.artipie.http.hm;
 import com.artipie.http.Connection;
 import com.artipie.http.Headers;
 import com.artipie.http.Response;
+import com.artipie.http.rs.Header;
 import com.artipie.http.rs.RsStatus;
 import com.google.common.collect.ImmutableList;
 import java.nio.ByteBuffer;
@@ -36,7 +37,6 @@ import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
-import org.cactoos.map.MapEntry;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
@@ -69,19 +69,29 @@ public final class RsHasHeaders extends TypeSafeMatcher<Response> {
     /**
      * Ctor.
      *
-     * @param headers Expected headers in any order.
+     * @param headers Expected header matchers in any order.
      */
-    public RsHasHeaders(final Collection<Entry<String, String>> headers) {
+    public RsHasHeaders(final Collection<? extends Entry<String, String>> headers) {
         this(
             Matchers.containsInAnyOrder(
                 headers.stream()
                     .<Entry<String, String>>map(
-                        original -> new MapEntry<>(original.getKey(), original.getValue())
+                        original -> new Header(original.getKey(), original.getValue())
                     )
                     .map(IsEqual::new)
                     .collect(Collectors.toList())
             )
         );
+    }
+
+    /**
+     * Ctor.
+     *
+     * @param headers Expected header matchers in any order.
+     */
+    @SafeVarargs
+    public RsHasHeaders(final Matcher<? super Entry<String, String>>... headers) {
+        this(Matchers.<Entry<String, String>>containsInAnyOrder(Arrays.asList(headers)));
     }
 
     /**
@@ -135,7 +145,7 @@ public final class RsHasHeaders extends TypeSafeMatcher<Response> {
                 () -> {
                     this.container.set(
                         ImmutableList.copyOf(headers).stream().<Entry<String, String>>map(
-                            original -> new MapEntry<>(original.getKey(), original.getValue())
+                            original -> new Header(original.getKey(), original.getValue())
                         ).collect(Collectors.toList())
                     );
                     return null;

--- a/src/main/java/com/artipie/http/rs/RsWithHeaders.java
+++ b/src/main/java/com/artipie/http/rs/RsWithHeaders.java
@@ -75,6 +75,17 @@ public final class RsWithHeaders implements Response {
      * Ctor.
      *
      * @param origin Origin response.
+     * @param headers Headers
+     */
+    @SafeVarargs
+    public RsWithHeaders(final Response origin, final Map.Entry<String, String>... headers) {
+        this(origin, new Headers.From(headers));
+    }
+
+    /**
+     * Ctor.
+     *
+     * @param origin Origin response.
      * @param name Name of header.
      * @param value Value of header.
      */


### PR DESCRIPTION
Closes #135 
Var args constructors in RsWithHeaders, Headers.From and RsHasHeaders classes