### PR TITLE
#187 - Default HTTP version in RequestLine

### DIFF
--- a/src/main/java/com/artipie/http/rq/RequestLine.java
+++ b/src/main/java/com/artipie/http/rq/RequestLine.java
@@ -48,6 +48,26 @@ public final class RequestLine {
 
     /**
      * Ctor.
+     *
+     * @param method Request method.
+     * @param uri Request URI.
+     */
+    public RequestLine(final RqMethod method, final String uri) {
+        this(method.value(), uri);
+    }
+
+    /**
+     * Ctor.
+     *
+     * @param method Request method.
+     * @param uri Request URI.
+     */
+    public RequestLine(final String method, final String uri) {
+        this(method, uri, "HTTP/1.1");
+    }
+
+    /**
+     * Ctor.
      * @param method The http method.
      * @param uri The http uri.
      * @param version The http version.

--- a/src/test/java/com/artipie/http/rq/RequestLineTest.java
+++ b/src/test/java/com/artipie/http/rq/RequestLineTest.java
@@ -41,4 +41,12 @@ public class RequestLineTest {
             Matchers.equalTo("GET /pub/WWW/TheProject.html HTTP/1.1\r\n")
         );
     }
+
+    @Test
+    public void defaultVersion() {
+        MatcherAssert.assertThat(
+            new RequestLine(RqMethod.PUT, "/file.txt").toString(),
+            Matchers.equalTo("PUT /file.txt HTTP/1.1\r\n")
+        );
+    }
 }

--- a/src/test/java/com/artipie/http/rq/RequestLineTest.java
+++ b/src/test/java/com/artipie/http/rq/RequestLineTest.java
@@ -43,7 +43,7 @@ public class RequestLineTest {
     }
 
     @Test
-    public void defaultVersion() {
+    public void shouldHaveDefaultVersionWhenNoneSpecified() {
         MatcherAssert.assertThat(
             new RequestLine(RqMethod.PUT, "/file.txt").toString(),
             Matchers.equalTo("PUT /file.txt HTTP/1.1\r\n")


### PR DESCRIPTION
Closes #187 
Default HTTP version in `RequestLine` is `HTTP/1.1` and constructor accepts `RqMethod` as method argument.