### PR TITLE
Public ctor in ContentWithSize

### DIFF
--- a/src/main/java/com/artipie/http/slice/ContentWithSize.java
+++ b/src/main/java/com/artipie/http/slice/ContentWithSize.java
@@ -52,7 +52,7 @@ public final class ContentWithSize implements Content {
      * @param body Body
      * @param headers Headers
      */
-    ContentWithSize(final Publisher<ByteBuffer> body,
+    public ContentWithSize(final Publisher<ByteBuffer> body,
         final Iterable<Map.Entry<String, String>> headers) {
         this.body = body;
         this.headers = headers;


### PR DESCRIPTION
Made contractor public in `ContentWithSize`, this class can be very useful in adapters to save content to storage.