### PR TITLE
#238 - added `Action` to `Permission.ByName`

### DIFF
--- a/src/main/java/com/artipie/http/auth/Permission.java
+++ b/src/main/java/com/artipie/http/auth/Permission.java
@@ -50,7 +50,17 @@ public interface Permission {
         /**
          * Action to perform.
          */
-        private final String action;
+        private final Action action;
+
+        /**
+         * Ctor.
+         * @param perm Permissions
+         * @param action Action
+         */
+        public ByName(final Permissions perm, final Action action) {
+            this.perm = perm;
+            this.action = action;
+        }
 
         /**
          * Ctor.
@@ -58,13 +68,19 @@ public interface Permission {
          * @param perm Permissions
          */
         public ByName(final String action, final Permissions perm) {
-            this.perm = perm;
-            this.action = action;
+            this(perm, new Action.ByString(action).get());
         }
 
         @Override
         public boolean allowed(final String user) {
-            return this.perm.allowed(user, this.action);
+            boolean res = false;
+            for (final String synonym : this.action.names()) {
+                if (this.perm.allowed(user, synonym)) {
+                    res = true;
+                    break;
+                }
+            }
+            return res;
         }
     }
 }

--- a/src/test/java/com/artipie/http/auth/PermissionByNameTest.java
+++ b/src/test/java/com/artipie/http/auth/PermissionByNameTest.java
@@ -1,0 +1,75 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.http.auth;
+
+import java.util.Arrays;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * Test for {@link Permission.ByName}.
+ * @since 0.16
+ */
+class PermissionByNameTest {
+
+    @ParameterizedTest
+    @CsvSource({
+        "READ,download,john",
+        "READ,r,john",
+        "READ,install,john",
+        "WRITE,w,alice",
+        "WRITE,write,alice",
+        "WRITE,upload,alice",
+        "WRITE,publish,alice",
+        "WRITE,push,alice",
+        "WRITE,deploy,mark",
+        "DELETE,delete,mark",
+        "DELETE,d,mark"
+    })
+    void checksAllActions(final Action.Standard action, final String perm, final String user) {
+        MatcherAssert.assertThat(
+            new Permission.ByName(
+                (name, act) -> user.equals(name) && act.equals(perm),
+                action
+            ).allowed(user),
+            new IsEqual<>(true)
+        );
+    }
+
+    @Test
+    void doesNotAllowWhenActionIsNotPresent() {
+        final String user = "jane";
+        MatcherAssert.assertThat(
+            new Permission.ByName(
+                (name, act) -> user.equals(name) && act.equals("a"),
+                () -> Arrays.asList("b", "c")
+            ).allowed(user),
+            new IsEqual<>(false)
+        );
+    }
+
+}

--- a/src/test/java/com/artipie/http/auth/SliceAuthTest.java
+++ b/src/test/java/com/artipie/http/auth/SliceAuthTest.java
@@ -50,7 +50,7 @@ public final class SliceAuthTest {
         MatcherAssert.assertThat(
             new SliceAuth(
                 new SliceSimple(new RsWithStatus(RsStatus.OK)),
-                new Permission.ByName("any", Permissions.FREE),
+                user -> true,
                 Identities.ANONYMOUS
             ).response(
                 new RequestLine("GET", "/foo", "HTTP/1.1").toString(),
@@ -66,7 +66,7 @@ public final class SliceAuthTest {
         MatcherAssert.assertThat(
             new SliceAuth(
                 new SliceSimple(new RsWithStatus(RsStatus.OK)),
-                new Permission.ByName("none", (name, action) -> false),
+                user -> false,
                 (line, headers) -> Optional.empty()
             ).response(
                 new RequestLine("POST", "/bar", "HTTP/1.2").toString(),
@@ -85,7 +85,7 @@ public final class SliceAuthTest {
         MatcherAssert.assertThat(
             new SliceAuth(
                 new SliceSimple(new RsWithStatus(RsStatus.OK)),
-                new Permission.ByName("action", (name, action) -> false),
+                new Permission.ByName("read", (name, action) -> false),
                 Identities.ANONYMOUS
             ).response(
                 new RequestLine("DELETE", "/baz", "HTTP/1.3").toString(),


### PR DESCRIPTION
Closes #238 
I've change `Permission.ByName` to use `Action` interface instead of string action representation.