### PR TITLE
#244 - work with Authentication.User instead of username

### DIFF
--- a/src/main/java/com/artipie/http/auth/Authentication.java
+++ b/src/main/java/com/artipie/http/auth/Authentication.java
@@ -39,11 +39,6 @@ import java.util.stream.Stream;
 public interface Authentication {
 
     /**
-     * Super user instance.
-     */
-    User SUPER_USER = new User("*");
-
-    /**
      * Find user by credentials.
      * @param username Username
      * @param password Password

--- a/src/main/java/com/artipie/http/auth/Authentication.java
+++ b/src/main/java/com/artipie/http/auth/Authentication.java
@@ -39,6 +39,11 @@ import java.util.stream.Stream;
 public interface Authentication {
 
     /**
+     * Super user instance.
+     */
+    User SUPER_USER = new User("*");
+
+    /**
      * Find user by credentials.
      * @param username Username
      * @param password Password

--- a/src/main/java/com/artipie/http/auth/BasicIdentities.java
+++ b/src/main/java/com/artipie/http/auth/BasicIdentities.java
@@ -57,7 +57,7 @@ public final class BasicIdentities implements Identities {
 
     @Override
     @SuppressWarnings("PMD.AvoidDeeplyNestedIfStmts")
-    public Optional<String> user(final String line,
+    public Optional<Authentication.User> user(final String line,
         final Iterable<Map.Entry<String, String>> headers) {
         return new RqHeaders(headers, Authorization.NAME).stream()
             .findFirst()
@@ -66,7 +66,6 @@ public final class BasicIdentities implements Identities {
             .map(dec -> dec.toString().split(":"))
             .flatMap(
                 cred -> this.auth.user(cred[0].trim(), cred[1].trim())
-                    .map(Authentication.User::name)
             );
     }
 }

--- a/src/main/java/com/artipie/http/auth/Identities.java
+++ b/src/main/java/com/artipie/http/auth/Identities.java
@@ -38,7 +38,7 @@ public interface Identities {
     /**
      * Resolve any request as anonymous user.
      */
-    Identities ANONYMOUS = (line, headers) -> Optional.of("anonymous");
+    Identities ANONYMOUS = (line, headers) -> Optional.of(new Authentication.User("anonymous"));
 
     /**
      * Try to find a user by request head.
@@ -46,5 +46,5 @@ public interface Identities {
      * @param headers Request headers
      * @return User name if found
      */
-    Optional<String> user(String line, Iterable<Map.Entry<String, String>> headers);
+    Optional<Authentication.User> user(String line, Iterable<Map.Entry<String, String>> headers);
 }

--- a/src/main/java/com/artipie/http/auth/Permission.java
+++ b/src/main/java/com/artipie/http/auth/Permission.java
@@ -34,7 +34,7 @@ public interface Permission {
      * @param user User name
      * @return True if authorized
      */
-    boolean allowed(String user);
+    boolean allowed(Authentication.User user);
 
     /**
      * Permission by name.
@@ -72,7 +72,7 @@ public interface Permission {
         }
 
         @Override
-        public boolean allowed(final String user) {
+        public boolean allowed(final Authentication.User user) {
             boolean res = false;
             for (final String synonym : this.action.names()) {
                 if (this.perm.allowed(user, synonym)) {

--- a/src/main/java/com/artipie/http/auth/Permissions.java
+++ b/src/main/java/com/artipie/http/auth/Permissions.java
@@ -31,13 +31,18 @@ package com.artipie.http.auth;
 public interface Permissions {
 
     /**
+     * Any user instance.
+     */
+    Authentication.User ANY_USER = new Authentication.User("*");
+
+    /**
      * Allow to perform all actions by all users.
      */
     Permissions FREE = (name, action) -> true;
 
     /**
-     * Check if user allowed to perform action.
-     * @param user User name
+     * Check if user is allowed to perform an action.
+     * @param user User
      * @param action Action to perform
      * @return True if allowed
      */

--- a/src/main/java/com/artipie/http/auth/Permissions.java
+++ b/src/main/java/com/artipie/http/auth/Permissions.java
@@ -37,11 +37,11 @@ public interface Permissions {
 
     /**
      * Check if user allowed to perform action.
-     * @param name User name
+     * @param user User name
      * @param action Action to perform
      * @return True if allowed
      */
-    boolean allowed(String name, String action);
+    boolean allowed(Authentication.User user, String action);
 
     /**
      * Abstract decorator for Permissions.
@@ -65,8 +65,8 @@ public interface Permissions {
         }
 
         @Override
-        public final boolean allowed(final String name, final String action) {
-            return this.origin.allowed(name, action);
+        public final boolean allowed(final Authentication.User user, final String action) {
+            return this.origin.allowed(user, action);
         }
     }
 
@@ -99,8 +99,8 @@ public interface Permissions {
         }
 
         @Override
-        public boolean allowed(final String name, final String act) {
-            return this.username.equals(name) && this.action.equals(act);
+        public boolean allowed(final Authentication.User user, final String act) {
+            return this.username.equals(user.name()) && this.action.equals(act);
         }
     }
 }

--- a/src/main/java/com/artipie/http/auth/SliceAuth.java
+++ b/src/main/java/com/artipie/http/auth/SliceAuth.java
@@ -96,7 +96,7 @@ public final class SliceAuth implements Slice {
             ).orElseGet(
                 () -> {
                     final Response rsp;
-                    if (this.perm.allowed("*")) {
+                    if (this.perm.allowed(Authentication.SUPER_USER)) {
                         rsp = this.origin.response(line, headers, body);
                     } else {
                         rsp = new RsWithHeaders(

--- a/src/main/java/com/artipie/http/auth/SliceAuth.java
+++ b/src/main/java/com/artipie/http/auth/SliceAuth.java
@@ -96,7 +96,7 @@ public final class SliceAuth implements Slice {
             ).orElseGet(
                 () -> {
                     final Response rsp;
-                    if (this.perm.allowed(Authentication.SUPER_USER)) {
+                    if (this.perm.allowed(Permissions.ANY_USER)) {
                         rsp = this.origin.response(line, headers, body);
                     } else {
                         rsp = new RsWithHeaders(

--- a/src/test/java/com/artipie/http/auth/BasicIdentitiesTest.java
+++ b/src/test/java/com/artipie/http/auth/BasicIdentitiesTest.java
@@ -68,7 +68,7 @@ public final class BasicIdentitiesTest {
         );
         MatcherAssert.assertThat(
             new BasicIdentities(this.auth).user("", headers),
-            new IsEqual<>(Optional.of("Aladdin"))
+            new IsEqual<>(Optional.of(new Authentication.User("Aladdin")))
         );
     }
 }

--- a/src/test/java/com/artipie/http/auth/PermissionByNameTest.java
+++ b/src/test/java/com/artipie/http/auth/PermissionByNameTest.java
@@ -50,12 +50,12 @@ class PermissionByNameTest {
         "DELETE,delete,mark",
         "DELETE,d,mark"
     })
-    void checksAllActions(final Action.Standard action, final String perm, final String user) {
+    void checksAllActions(final Action.Standard action, final String perm, final String name) {
         MatcherAssert.assertThat(
             new Permission.ByName(
-                (name, act) -> user.equals(name) && act.equals(perm),
+                (identity, act) -> name.equals(identity.name()) && act.equals(perm),
                 action
-            ).allowed(user),
+            ).allowed(new Authentication.User(name)),
             new IsEqual<>(true)
         );
     }
@@ -65,9 +65,9 @@ class PermissionByNameTest {
         final String user = "jane";
         MatcherAssert.assertThat(
             new Permission.ByName(
-                (name, act) -> user.equals(name) && act.equals("a"),
+                (identity, act) -> user.equals(identity.name()) && act.equals("a"),
                 () -> Arrays.asList("b", "c")
-            ).allowed(user),
+            ).allowed(new Authentication.User(user)),
             new IsEqual<>(false)
         );
     }

--- a/src/test/java/com/artipie/http/auth/PermissionsTest.java
+++ b/src/test/java/com/artipie/http/auth/PermissionsTest.java
@@ -38,17 +38,17 @@ public final class PermissionsTest {
 
     @Test
     void wrapDelegatesToOrigin() {
-        final String user = "user";
+        final String name = "user";
         final String act = "act";
         final boolean result = true;
         MatcherAssert.assertThat(
             "Result is forwarded from delegate without modification",
             new TestPermissions(
-                (username, action) -> {
+                (identity, action) -> {
                     MatcherAssert.assertThat(
                         "Username is forwarded to delegate without modification",
-                        username,
-                        new IsEqual<>(user)
+                        identity,
+                        new IsEqual<>(new Authentication.User(name))
                     );
                     MatcherAssert.assertThat(
                         "Action is forwarded to delegate without modification",
@@ -57,7 +57,7 @@ public final class PermissionsTest {
                     );
                     return result;
                 }
-            ).allowed(user, act),
+            ).allowed(new Authentication.User(name), act),
             new IsEqual<>(result)
         );
     }
@@ -74,7 +74,8 @@ public final class PermissionsTest {
         final boolean allow
     ) {
         MatcherAssert.assertThat(
-            new Permissions.Single("Aladdin", "read").allowed(username, action),
+            new Permissions.Single("Aladdin", "read")
+                .allowed(new Authentication.User(username), action),
             new IsEqual<>(allow)
         );
     }


### PR DESCRIPTION
Closes #244 
Made `Identities`, `Permission` and `Permissions` work with `Authentication.User` instead of user name.