### PR TITLE
#251 - StatefulResponse renamed to CachedResponse and fixed

### DIFF
--- a/src/main/java/com/artipie/http/hm/SliceHasResponse.java
+++ b/src/main/java/com/artipie/http/hm/SliceHasResponse.java
@@ -28,6 +28,7 @@ import com.artipie.http.Headers;
 import com.artipie.http.Response;
 import com.artipie.http.Slice;
 import com.artipie.http.rq.RequestLine;
+import com.artipie.http.rs.CachedResponse;
 import io.reactivex.Flowable;
 import org.cactoos.func.StickyFunc;
 import org.cactoos.func.UncheckedFunc;
@@ -73,7 +74,7 @@ public final class SliceHasResponse extends TypeSafeMatcher<Slice> {
         this.rsp = rsp;
         this.target = new UncheckedFunc<>(
             new StickyFunc<>(
-                slice -> new StatefulResponse(
+                slice -> new CachedResponse(
                     slice.response(line.toString(), headers, body)
                 )
             )

--- a/src/test/java/com/artipie/http/rs/CachedResponseTest.java
+++ b/src/test/java/com/artipie/http/rs/CachedResponseTest.java
@@ -1,0 +1,71 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.http.rs;
+
+import com.artipie.asto.Content;
+import com.artipie.asto.ext.PublisherAs;
+import io.reactivex.Flowable;
+import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test for {@link CachedResponse}.
+ *
+ * @since 0.17
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ */
+class CachedResponseTest {
+
+    @Test
+    void shouldReadBodyOnFirstSend() {
+        final AtomicBoolean terminated = new AtomicBoolean();
+        final Flowable<ByteBuffer> publisher = Flowable.<ByteBuffer>empty()
+            .doOnTerminate(() -> terminated.set(true));
+        new CachedResponse(new RsWithBody(publisher)).send(
+            (status, headers, body) -> CompletableFuture.allOf()
+        ).toCompletableFuture().join();
+        MatcherAssert.assertThat(terminated.get(), new IsEqual<>(true));
+    }
+
+    @Test
+    void shouldReplayBody() {
+        final byte[] content = "content".getBytes();
+        final CachedResponse cached = new CachedResponse(
+            new RsWithBody(new Content.OneTime(new Content.From(content)))
+        );
+        cached.send(
+            (status, headers, body) -> CompletableFuture.allOf()
+        ).toCompletableFuture().join();
+        final AtomicReference<byte[]> capture = new AtomicReference<>();
+        cached.send(
+            (status, headers, body) -> new PublisherAs(body).bytes().thenAccept(capture::set)
+        ).toCompletableFuture().join();
+        MatcherAssert.assertThat(capture.get(), new IsEqual<>(content));
+    }
+}

--- a/src/test/java/com/artipie/http/rs/common/RsJsonTest.java
+++ b/src/test/java/com/artipie/http/rs/common/RsJsonTest.java
@@ -26,7 +26,7 @@ package com.artipie.http.rs.common;
 import com.artipie.http.headers.Header;
 import com.artipie.http.hm.RsHasBody;
 import com.artipie.http.hm.RsHasHeaders;
-import com.artipie.http.hm.StatefulResponse;
+import com.artipie.http.rs.CachedResponse;
 import java.nio.charset.StandardCharsets;
 import javax.json.Json;
 import org.hamcrest.MatcherAssert;
@@ -51,7 +51,7 @@ final class RsJsonTest {
     @Test
     void headersHasContentSize() {
         MatcherAssert.assertThat(
-            new StatefulResponse(new RsJson(Json.createObjectBuilder().add("bar", 0))),
+            new CachedResponse(new RsJson(Json.createObjectBuilder().add("bar", 0))),
             new RsHasHeaders(
                 Matchers.equalTo(new Header("Content-Length", "9")),
                 Matchers.anything()
@@ -62,7 +62,7 @@ final class RsJsonTest {
     @Test
     void headersHasContentType() {
         MatcherAssert.assertThat(
-            new StatefulResponse(
+            new CachedResponse(
                 new RsJson(
                     () -> Json.createObjectBuilder().add("baz", "a").build(),
                     StandardCharsets.UTF_16BE

--- a/src/test/java/com/artipie/http/rs/common/RsTextTest.java
+++ b/src/test/java/com/artipie/http/rs/common/RsTextTest.java
@@ -26,7 +26,7 @@ package com.artipie.http.rs.common;
 import com.artipie.http.headers.Header;
 import com.artipie.http.hm.RsHasBody;
 import com.artipie.http.hm.RsHasHeaders;
-import com.artipie.http.hm.StatefulResponse;
+import com.artipie.http.rs.CachedResponse;
 import java.nio.charset.StandardCharsets;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -43,7 +43,7 @@ final class RsTextTest {
     void bodyIsCorrect() {
         final String src = "hello";
         MatcherAssert.assertThat(
-            new StatefulResponse(new RsText(src, StandardCharsets.UTF_16)),
+            new CachedResponse(new RsText(src, StandardCharsets.UTF_16)),
             new RsHasBody(src, StandardCharsets.UTF_16)
         );
     }
@@ -51,7 +51,7 @@ final class RsTextTest {
     @Test
     void headersHasContentSize() {
         MatcherAssert.assertThat(
-            new StatefulResponse(new RsText("four")),
+            new CachedResponse(new RsText("four")),
             new RsHasHeaders(
                 Matchers.equalTo(new Header("Content-Length", "4")),
                 Matchers.anything()
@@ -62,7 +62,7 @@ final class RsTextTest {
     @Test
     void headersHasContentType() {
         MatcherAssert.assertThat(
-            new StatefulResponse(new RsText("test", StandardCharsets.UTF_16LE)),
+            new CachedResponse(new RsText("test", StandardCharsets.UTF_16LE)),
             new RsHasHeaders(
                 Matchers.equalTo(
                     new Header("Content-Type", "text/plain; charset=UTF-16LE")


### PR DESCRIPTION
Closes #251 
`StatefulResponse` renamed to `CachedResponse` and changed to keep copy of body