### PR TITLE
#261 - Added absent auth scheme

### DIFF
--- a/src/main/java/com/artipie/http/auth/AuthScheme.java
+++ b/src/main/java/com/artipie/http/auth/AuthScheme.java
@@ -25,6 +25,7 @@ package com.artipie.http.auth;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 /**
@@ -33,6 +34,23 @@ import java.util.concurrent.CompletionStage;
  * @since 0.17
  */
 public interface AuthScheme {
+
+    /**
+     * Absent auth scheme that authenticates any request as "anonymous" user.
+     */
+    AuthScheme NONE = ignored -> CompletableFuture.completedFuture(
+        new AuthScheme.Result() {
+            @Override
+            public Optional<Authentication.User> user() {
+                return Optional.of(new Authentication.User("anonymous"));
+            }
+
+            @Override
+            public String challenge() {
+                throw new UnsupportedOperationException();
+            }
+        }
+    );
 
     /**
      * Authenticate HTTP request by it's headers.

--- a/src/test/java/com/artipie/http/auth/AuthSchemeNoneTest.java
+++ b/src/test/java/com/artipie/http/auth/AuthSchemeNoneTest.java
@@ -1,0 +1,49 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.http.auth;
+
+import com.artipie.http.Headers;
+import java.util.Optional;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link AuthScheme#NONE}.
+ *
+ * @since 0.18
+ */
+final class AuthSchemeNoneTest {
+
+    @Test
+    void shouldAuthEmptyHeadersAsAnonymous() {
+        MatcherAssert.assertThat(
+            AuthScheme.NONE.authenticate(Headers.EMPTY)
+                .toCompletableFuture().join()
+                .user()
+                .map(Authentication.User::name),
+            new IsEqual<>(Optional.of("anonymous"))
+        );
+    }
+}


### PR DESCRIPTION
#261 
Added absent auth scheme that is useful as `AuthScheme` implementation when no auth is required.