### PR TITLE
Fixed ContentWithSize using correct header name

### DIFF
--- a/src/test/java/com/artipie/http/slice/ContentWithSizeTest.java
+++ b/src/test/java/com/artipie/http/slice/ContentWithSizeTest.java
@@ -21,52 +21,29 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
 package com.artipie.http.slice;
 
 import com.artipie.asto.Content;
-import com.artipie.http.rq.RqHeaders;
-import java.nio.ByteBuffer;
-import java.util.Map;
-import java.util.Optional;
-import org.reactivestreams.Publisher;
-import org.reactivestreams.Subscriber;
+import com.artipie.http.Headers;
+import com.artipie.http.headers.ContentLength;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Test;
 
 /**
- * Content with size from headers.
- * @since 0.6
+ * Unit test for {@link ContentWithSize}.
+ * @since 0.18
  */
-public final class ContentWithSize implements Content {
+final class ContentWithSizeTest {
 
-    /**
-     * Request body.
-     */
-    private final Publisher<ByteBuffer> body;
-
-    /**
-     * Request headers.
-     */
-    private final Iterable<Map.Entry<String, String>> headers;
-
-    /**
-     * Content with size from body and headers.
-     * @param body Body
-     * @param headers Headers
-     */
-    public ContentWithSize(final Publisher<ByteBuffer> body,
-        final Iterable<Map.Entry<String, String>> headers) {
-        this.body = body;
-        this.headers = headers;
-    }
-
-    @Override
-    public Optional<Long> size() {
-        return new RqHeaders(this.headers, "content-length")
-            .stream().findFirst()
-            .map(Long::parseLong);
-    }
-
-    @Override
-    public void subscribe(final Subscriber<? super ByteBuffer> subscriber) {
-        this.body.subscribe(subscriber);
+    @Test
+    void parsesHeaderValue() {
+        final long length = 100L;
+        MatcherAssert.assertThat(
+            new ContentWithSize(Content.EMPTY, new Headers.From(new ContentLength(length))).size()
+                .orElse(0L),
+            new IsEqual<>(length)
+        );
     }
 }


### PR DESCRIPTION
Fixes #293 - using `content-length` instead of `content-size` in
ContentWithSize class, added a test.