### PR TITLE
Added `override` parameter to `RsWithHeaders`

### DIFF
--- a/src/main/java/com/artipie/http/rs/RsWithBody.java
+++ b/src/main/java/com/artipie/http/rs/RsWithBody.java
@@ -137,7 +137,9 @@ public final class RsWithBody implements Response {
      */
     private static Response withHeaders(final Response origin, final Optional<Long> size) {
         return size.<Response>map(
-            val -> new RsWithHeaders(origin, new ContentLength(String.valueOf(val)))
+            val -> new RsWithHeaders(
+                origin, new Headers.From(new ContentLength(String.valueOf(val))), true
+            )
         ).orElse(origin);
     }
 

--- a/src/main/java/com/artipie/http/rs/RsWithHeaders.java
+++ b/src/main/java/com/artipie/http/rs/RsWithHeaders.java
@@ -146,7 +146,8 @@ public final class RsWithHeaders implements Response {
                 this.headers.forEach(list::add);
                 hrs.forEach(
                     item -> {
-                        if (list.stream().noneMatch(val -> val.getKey().equals(item.getKey()))) {
+                        if (list.stream()
+                            .noneMatch(val -> val.getKey().equalsIgnoreCase(item.getKey()))) {
                             list.add(item);
                         }
                     }

--- a/src/main/java/com/artipie/http/rs/RsWithHeaders.java
+++ b/src/main/java/com/artipie/http/rs/RsWithHeaders.java
@@ -9,6 +9,8 @@ import com.artipie.http.Connection;
 import com.artipie.http.Headers;
 import com.artipie.http.Response;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletionStage;
 import org.reactivestreams.Publisher;
@@ -31,14 +33,31 @@ public final class RsWithHeaders implements Response {
     private final Headers headers;
 
     /**
+     * Should header value be replaced if already exist? False by default.
+     */
+    private final boolean override;
+
+    /**
+     * Ctor.
+     *
+     * @param origin Response
+     * @param headers Headers
+     * @param override Should header value be replaced if already exist?
+     */
+    public RsWithHeaders(final Response origin, final Headers headers, final boolean override) {
+        this.origin = origin;
+        this.headers = headers;
+        this.override = override;
+    }
+
+    /**
      * Ctor.
      *
      * @param origin Response
      * @param headers Headers
      */
     public RsWithHeaders(final Response origin, final Headers headers) {
-        this.origin = origin;
-        this.headers = headers;
+        this(origin, headers, false);
     }
 
     /**
@@ -75,7 +94,7 @@ public final class RsWithHeaders implements Response {
 
     @Override
     public CompletionStage<Void> send(final Connection con) {
-        return this.origin.send(new RsWithHeaders.ConWithHeaders(con, this.headers));
+        return this.origin.send(new RsWithHeaders.ConWithHeaders(con, this.headers, this.override));
     }
 
     /**
@@ -95,16 +114,24 @@ public final class RsWithHeaders implements Response {
         private final Iterable<Map.Entry<String, String>> headers;
 
         /**
+         * Should header value be replaced if already exist?
+         */
+        private final boolean override;
+
+        /**
          * Ctor.
          *
          * @param origin Connection
          * @param headers Headers
+         * @param override Should header value be replaced if already exist?
          */
         private ConWithHeaders(
             final Connection origin,
-            final Iterable<Map.Entry<String, String>> headers) {
+            final Iterable<Map.Entry<String, String>> headers,
+            final boolean override) {
             this.origin = origin;
             this.headers = headers;
+            this.override = override;
         }
 
         @Override
@@ -113,11 +140,22 @@ public final class RsWithHeaders implements Response {
             final Headers hrs,
             final Publisher<ByteBuffer> body
         ) {
-            return this.origin.accept(
-                status,
-                new Headers.From(this.headers, hrs),
-                body
-            );
+            final Headers res;
+            if (this.override) {
+                final List<Map.Entry<String, String>> list = new ArrayList<>(10);
+                this.headers.forEach(list::add);
+                hrs.forEach(
+                    item -> {
+                        if (list.stream().noneMatch(val -> val.getKey().equals(item.getKey()))) {
+                            list.add(item);
+                        }
+                    }
+                );
+                res = new Headers.From(list);
+            } else {
+                res = new Headers.From(this.headers, hrs);
+            }
+            return this.origin.accept(status, res, body);
         }
     }
 }

--- a/src/test/java/com/artipie/http/rs/RsWithBodyTest.java
+++ b/src/test/java/com/artipie/http/rs/RsWithBodyTest.java
@@ -17,6 +17,8 @@ import org.junit.jupiter.api.Test;
 /**
  * Test for {@link RsWithBody}.
  * @since 0.9
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ * @checkstyle MagicNumberCheck (500 lines)
  */
 final class RsWithBodyTest {
 
@@ -52,6 +54,18 @@ final class RsWithBodyTest {
         final int size = 17;
         MatcherAssert.assertThat(
             new RsWithBody(new Content.From(new byte[size])),
+            new RsHasHeaders(new ContentLength(size))
+        );
+    }
+
+    @Test
+    void overridesContentSizeHeader() {
+        final int size = 17;
+        MatcherAssert.assertThat(
+            new RsWithBody(
+                new RsWithHeaders(StandardRs.OK, new ContentLength(100)),
+                new Content.From(new byte[size])
+            ),
             new RsHasHeaders(new ContentLength(size))
         );
     }

--- a/src/test/java/com/artipie/http/rs/RsWithHeadersTest.java
+++ b/src/test/java/com/artipie/http/rs/RsWithHeadersTest.java
@@ -4,6 +4,8 @@
  */
 package com.artipie.http.rs;
 
+import com.artipie.asto.Content;
+import com.artipie.http.Headers;
 import com.artipie.http.headers.Header;
 import com.artipie.http.hm.RsHasHeaders;
 import org.cactoos.map.MapEntry;
@@ -14,6 +16,7 @@ import org.junit.jupiter.api.Test;
  * Test case for {@link RsWithHeaders}.
  * @since 0.9
  */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public class RsWithHeadersTest {
 
     @Test
@@ -23,6 +26,36 @@ public class RsWithHeadersTest {
         MatcherAssert.assertThat(
             new RsWithHeaders(new RsWithStatus(RsStatus.OK), new MapEntry<>(name, value)),
             new RsHasHeaders(new Header(name, value))
+        );
+    }
+
+    @Test
+    void doesNotFilterDuplicatedHeaders() {
+        final String name = "Duplicated header";
+        final String one = "one";
+        final String two = "two";
+        MatcherAssert.assertThat(
+            new RsWithHeaders(
+                new RsFull(RsStatus.OK, new Headers.From(name, one), Content.EMPTY),
+                new MapEntry<>(name, two)
+            ),
+            new RsHasHeaders(
+                new Header(name, one), new Header(name, two), new Header("Content-Length", "0")
+            )
+        );
+    }
+
+    @Test
+    void filtersDuplicatedHeaders() {
+        final String name = "Duplicated header";
+        final String one = "one";
+        final String two = "two";
+        MatcherAssert.assertThat(
+            new RsWithHeaders(
+                new RsFull(RsStatus.OK, new Headers.From(name, one), Content.EMPTY),
+                new Headers.From(name, two), true
+            ),
+            new RsHasHeaders(new Header(name, two), new Header("Content-Length", "0"))
         );
     }
 }


### PR DESCRIPTION
Closes #305 
Added `override` parameter to `RsWithHeaders`: if this parameter is true, origin header values are replaced with provided headers values. This feature is now used in `RsWithBody` to avoid `Content-Length` header duplication/mismatch.