### PR TITLE
Response matcher for JSON

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@ SOFTWARE.
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -160,6 +161,12 @@ SOFTWARE.
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
       <version>10.0.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>wtf.g4s8</groupId>
+      <artifactId>matchers-json</artifactId>
+      <version>1.0.3</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/com/artipie/http/hm/IsJson.java
+++ b/src/main/java/com/artipie/http/hm/IsJson.java
@@ -1,0 +1,50 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/npm-adapter/LICENSE.txt
+ */
+package com.artipie.http.hm;
+
+import java.io.ByteArrayInputStream;
+import javax.json.Json;
+import javax.json.JsonReader;
+import javax.json.JsonStructure;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+/**
+ * Body matcher for JSON.
+ * @since 1.0
+ */
+public final class IsJson extends TypeSafeMatcher<byte[]> {
+
+    /**
+     * Json matcher.
+     */
+    private final Matcher<? extends JsonStructure> matcher;
+
+    /**
+     * New JSON body matcher.
+     * @param matcher JSON structure matcher
+     */
+    public IsJson(final Matcher<? extends JsonStructure> matcher) {
+        this.matcher = matcher;
+    }
+
+    @Override
+    public void describeTo(final Description desc) {
+        desc.appendText("JSON ").appendDescriptionOf(this.matcher);
+    }
+
+    @Override
+    public boolean matchesSafely(final byte[] body) {
+        try (JsonReader reader = Json.createReader(new ByteArrayInputStream(body))) {
+            return this.matcher.matches(reader.read());
+        }
+    }
+
+    @Override
+    public void describeMismatchSafely(final byte[] item, final Description desc) {
+        desc.appendText("was ").appendValue(new String(item));
+    }
+}

--- a/src/test/java/com/artipie/http/hm/IsJsonTest.java
+++ b/src/test/java/com/artipie/http/hm/IsJsonTest.java
@@ -1,0 +1,60 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/npm-adapter/LICENSE.txt
+ */
+package com.artipie.http.hm;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import wtf.g4s8.hamcrest.json.JsonContains;
+import wtf.g4s8.hamcrest.json.JsonHas;
+import wtf.g4s8.hamcrest.json.JsonValueIs;
+
+/**
+ * Test case for {@link IsJson}.
+ * @since 1.0
+ * @checkstyle MagicNumberCheck (500 lines)
+ */
+final class IsJsonTest {
+
+    @Test
+    void matchesJsonObject() {
+        MatcherAssert.assertThat(
+            "{\"value\": 4}".getBytes(),
+            new IsJson(new JsonHas("value", new JsonValueIs(4)))
+        );
+    }
+
+    @Test
+    void doesntMatchObject() {
+        MatcherAssert.assertThat(
+            "{}".getBytes(),
+            Matchers.not(new IsJson(new JsonHas("foo", new JsonValueIs(0))))
+        );
+    }
+
+    @Test
+    void matchesJsonArray() {
+        MatcherAssert.assertThat(
+            "[1, 2, 3]".getBytes(),
+            new IsJson(
+                new JsonContains(
+                    new JsonValueIs(1),
+                    new JsonValueIs(2),
+                    new JsonValueIs(3)
+                )
+            )
+        );
+    }
+
+    @Test
+    void doesntMatchArray() {
+        MatcherAssert.assertThat(
+            "{}".getBytes(),
+            Matchers.not(
+                new IsJson(new JsonContains(new JsonValueIs(5)))
+            )
+        );
+    }
+}


### PR DESCRIPTION
For #324 - added JSON response matcher accepting
`? extends JsonStructure` - it's either `JsonObject` or
`JsonArray`. Added tests for matcher.

<!-- @artipie/members -->