### PR TITLE
Added reactive processor tokenizer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -235,7 +235,7 @@ SOFTWARE.
                     <limit>
                       <counter>CLASS</counter>
                       <value>MISSEDCOUNT</value>
-                      <maximum>25</maximum>
+                      <maximum>26</maximum>
                     </limit>
                   </limits>
                 </rule>

--- a/src/main/java/com/artipie/http/misc/ByteBufferTokenizer.java
+++ b/src/main/java/com/artipie/http/misc/ByteBufferTokenizer.java
@@ -2,11 +2,12 @@
  * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
  * https://github.com/artipie/npm-adapter/LICENSE.txt
  */
-package com.artipie.http.rq.multipart;
+package com.artipie.http.misc;
 
 import java.io.Closeable;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import javax.annotation.concurrent.NotThreadSafe;
 
 /**
  * ByteBuffer tokenizer splits sequence of chunks of {@link ByteBuffer}s separated
@@ -31,6 +32,7 @@ import java.util.Arrays;
  * @since 1.0
  * @checkstyle MethodBodyCommentsCheck (500 lines)
  */
+@NotThreadSafe
 public final class ByteBufferTokenizer implements Closeable {
 
     /**
@@ -133,6 +135,8 @@ public final class ByteBufferTokenizer implements Closeable {
 
     /**
      * Flush buffer, sends all remaining data to receiver.
+     * This method guarantee that the receiver will be called with {@code end} param, even if
+     * the buffer doesn't contain any bytes.
      */
     private void flush() {
         final ByteBuffer dup = this.acc.duplicate();

--- a/src/main/java/com/artipie/http/misc/DummySubscription.java
+++ b/src/main/java/com/artipie/http/misc/DummySubscription.java
@@ -2,7 +2,7 @@
  * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
  * https://github.com/artipie/npm-adapter/LICENSE.txt
  */
-package com.artipie.http.rq.multipart;
+package com.artipie.http.misc;
 
 import org.reactivestreams.Subscription;
 
@@ -11,7 +11,7 @@ import org.reactivestreams.Subscription;
  * It's a requirement of reactive-streams specification to
  * call {@code onSubscribe} on subscriber before any other call.
  */
-enum DummySubscription implements Subscription {
+public enum DummySubscription implements Subscription {
     /**
      * Dummy value.
      */

--- a/src/main/java/com/artipie/http/misc/TokenizerFlatProc.java
+++ b/src/main/java/com/artipie/http/misc/TokenizerFlatProc.java
@@ -1,0 +1,188 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/npm-adapter/LICENSE.txt
+ */
+package com.artipie.http.misc;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.reactivestreams.Processor;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+/**
+ * Byte buffer publisher processor tokenizer as a flat publisher of byte buffers.
+ *
+ * @since 1.0
+ */
+public final class TokenizerFlatProc implements Processor<ByteBuffer, ByteBuffer>,
+    ByteBufferTokenizer.Receiver {
+
+    /**
+     * Initial buffer capacity.
+     */
+    private static final int CAP_BUF = 128;
+
+    /**
+     * Tokenizer.
+     */
+    private final ByteBufferTokenizer tokenizer;
+
+    /**
+     * Buffer accumulator.
+     */
+    private final BufAccumulator accumulator;
+
+    /**
+     * Completed flag.
+     */
+    private final AtomicBoolean completed;
+
+    /**
+     * Subscription lock.
+     */
+    private final Object lock;
+
+    /**
+     * Downstream subscriber.
+     */
+    private volatile Subscriber<? super ByteBuffer> downstream;
+
+    /**
+     * Upstream proxy.
+     */
+    private volatile ProxySubscription upstream;
+
+    /**
+     * New tokenizer with default capacity.
+     * @param delim Delimiter
+     */
+    public TokenizerFlatProc(final String delim) {
+        this(delim, TokenizerFlatProc.CAP_BUF);
+    }
+
+    /**
+     * New tokenizer processor.
+     * @param delim Delimiter token
+     * @param cap Buffer capacity in bytes
+     */
+    public TokenizerFlatProc(final String delim, final int cap) {
+        this.tokenizer = new ByteBufferTokenizer(this, delim.getBytes(StandardCharsets.US_ASCII));
+        this.accumulator = new BufAccumulator(cap);
+        this.completed = new AtomicBoolean();
+        this.lock = new Object();
+    }
+
+    @Override
+    public void subscribe(final Subscriber<? super ByteBuffer> sub) {
+        synchronized (this.lock) {
+            if (this.downstream == null) {
+                this.downstream = sub;
+            } else {
+                sub.onSubscribe(DummySubscription.VALUE);
+                sub.onError(new IllegalStateException("Only one downstream supported"));
+                return;
+            }
+            if (this.upstream != null) {
+                this.downstream.onSubscribe(this.upstream);
+            }
+        }
+    }
+
+    @Override
+    public void onSubscribe(final Subscription sub) {
+        synchronized (this.lock) {
+            if (this.upstream != null) {
+                throw new IllegalStateException("Already subscribed");
+            }
+            this.upstream = new ProxySubscription(sub);
+            if (this.downstream != null) {
+                this.downstream.onSubscribe(this.upstream);
+            }
+        }
+    }
+
+    @Override
+    public void onNext(final ByteBuffer buffer) {
+        this.tokenizer.push(buffer);
+    }
+
+    @Override
+    public void onError(final Throwable err) {
+        this.downstream.onError(err);
+    }
+
+    @Override
+    public void onComplete() {
+        if (this.completed.compareAndSet(false, true)) {
+            this.tokenizer.close();
+        }
+    }
+
+    @Override
+    public void receive(final ByteBuffer next, final boolean end) {
+        this.upstream.receive();
+        this.accumulator.push(next);
+        if (end) {
+            this.accumulator.read(this.downstream::onNext);
+            if (this.completed.get()) {
+                this.downstream.onComplete();
+                this.accumulator.close();
+            }
+        }
+    }
+
+    /**
+     * Upstream subscription proxy.
+     * <p>
+     * It handle requests from downstream and translate it to upstream requests
+     * depends on about of processed items.
+     * </p>
+     * @since 1.0
+     * @todo #299:30min Implement this subscription correctly.
+     *  Now it requests MAX_VALUE from upstream on first request from downstream.
+     *  It should count requests from downstream and request upstream only on demand.
+     */
+    private static final class ProxySubscription implements Subscription {
+
+        /**
+         * Upstream subscription.
+         */
+        private final Subscription upstream;
+
+        /**
+         * Requested flag.
+         */
+        private final AtomicBoolean requested;
+
+        /**
+         * New proxy for upstream.
+         * @param upstream Subscription
+         */
+        ProxySubscription(final Subscription upstream) {
+            this.upstream = upstream;
+            this.requested = new AtomicBoolean();
+        }
+
+        @Override
+        public void request(final long amount) {
+            if (this.requested.compareAndSet(false, true)) {
+                this.upstream.request(Long.MAX_VALUE);
+            }
+        }
+
+        @Override
+        public void cancel() {
+            this.upstream.cancel();
+        }
+
+        /**
+         * Notify item received.
+         * @checkstyle NonStaticMethodCheck (10 lines)
+         */
+        public void receive() {
+            // not implemented
+        }
+    }
+}

--- a/src/main/java/com/artipie/http/rq/multipart/MultiPart.java
+++ b/src/main/java/com/artipie/http/rq/multipart/MultiPart.java
@@ -5,6 +5,9 @@
 package com.artipie.http.rq.multipart;
 
 import com.artipie.http.Headers;
+import com.artipie.http.misc.BufAccumulator;
+import com.artipie.http.misc.ByteBufferTokenizer;
+import com.artipie.http.misc.DummySubscription;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ExecutorService;

--- a/src/main/java/com/artipie/http/rq/multipart/MultipartHeaders.java
+++ b/src/main/java/com/artipie/http/rq/multipart/MultipartHeaders.java
@@ -6,6 +6,7 @@ package com.artipie.http.rq.multipart;
 
 import com.artipie.http.Headers;
 import com.artipie.http.headers.Header;
+import com.artipie.http.misc.BufAccumulator;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;

--- a/src/test/java/com/artipie/http/misc/BufAccumulatorTest.java
+++ b/src/test/java/com/artipie/http/misc/BufAccumulatorTest.java
@@ -2,7 +2,7 @@
  * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
  * https://github.com/artipie/npm-adapter/LICENSE.txt
  */
-package com.artipie.http.rq.multipart;
+package com.artipie.http.misc;
 
 import java.nio.ByteBuffer;
 import org.hamcrest.MatcherAssert;

--- a/src/test/java/com/artipie/http/misc/ByteBufferTokenizerTest.java
+++ b/src/test/java/com/artipie/http/misc/ByteBufferTokenizerTest.java
@@ -2,7 +2,7 @@
  * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
  * https://github.com/artipie/npm-adapter/LICENSE.txt
  */
-package com.artipie.http.rq.multipart;
+package com.artipie.http.misc;
 
 import java.io.Closeable;
 import java.nio.ByteBuffer;

--- a/src/test/java/com/artipie/http/misc/TokenizerFlatProcTest.java
+++ b/src/test/java/com/artipie/http/misc/TokenizerFlatProcTest.java
@@ -1,0 +1,44 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/npm-adapter/LICENSE.txt
+ */
+package com.artipie.http.misc;
+
+import com.artipie.asto.Remaining;
+import io.reactivex.Flowable;
+import java.nio.ByteBuffer;
+import java.util.List;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link TokenizerFlatProc}.
+ * @since 1.0
+ */
+final class TokenizerFlatProcTest {
+
+    @Test
+    void splitByDelimiter() {
+        final Flowable<ByteBuffer> src = Flowable.fromArray(
+            "hello ", "with ", "a ", "space\n ",
+            "multi-line ", "strings\nand\n\nsome",
+            " \nspaces ", "in ", "the ", "end ", " ", " "
+        ).map(str -> ByteBuffer.wrap(str.getBytes()));
+        final TokenizerFlatProc target = new TokenizerFlatProc("\n");
+        src.subscribe(target);
+        final List<String> split = Flowable.fromPublisher(target)
+            .map(buf -> new String(new Remaining(buf).bytes())).toList().blockingGet();
+        MatcherAssert.assertThat(
+            split,
+            Matchers.contains(
+                "hello with a space",
+                " multi-line strings",
+                "and",
+                "",
+                "some ",
+                "spaces in the end   "
+            )
+        );
+    }
+}


### PR DESCRIPTION
For #299 - reactive processor implementation
based on ByteBufferTokenizer - it takes ByteBuffer
publisher as upstream and split it by delimiters into
ByteBuffers and send to downstream.