### PR TITLE
MultipartHeaders: header values are not case-insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.23.1
+
+ - fix: MultipartHeaders: header values are not case-insensitive (#376) 
+
 ## v0.23
 
  - feat: added rq line to AuthScheme and token auth header (#372) 

--- a/src/main/java/com/artipie/http/rq/multipart/MultipartHeaders.java
+++ b/src/main/java/com/artipie/http/rq/multipart/MultipartHeaders.java
@@ -66,7 +66,7 @@ final class MultipartHeaders implements Headers {
                                 final String[] parts = line.split(":");
                                 return new Header(
                                     parts[0].trim().toLowerCase(Locale.US),
-                                    parts[1].trim().toLowerCase(Locale.US)
+                                    parts[1].trim()
                                 );
                             }
                         ).collect(Collectors.toList())

--- a/src/test/java/com/artipie/http/rq/multipart/MultipartHeadersTest.java
+++ b/src/test/java/com/artipie/http/rq/multipart/MultipartHeadersTest.java
@@ -26,7 +26,8 @@ final class MultipartHeadersTest {
             "\r\n",
             "Accept: application/json",
             "Content-length: 100",
-            "Connection: keep-alive"
+            "Connection: keep-alive",
+            "Content-Disposition: form-data; name=\"content\"; filename=\"My-Test.txt\""
         );
         for (int pos = 0, take = 3; pos < source.length(); pos += take, ++take) {
             if (pos + take > source.length()) {
@@ -40,7 +41,10 @@ final class MultipartHeadersTest {
             Matchers.containsInAnyOrder(
                 new Header("Accept", "application/json"),
                 new Header("Connection", "keep-alive"),
-                new Header("Content-length", "100")
+                new Header("Content-length", "100"),
+                new Header(
+                    "Content-Disposition", "form-data; name=\"content\"; filename=\"My-Test.txt\""
+                )
             )
         );
     }


### PR DESCRIPTION
Closes #376 
Fixed `MultipartHeaders` not to make header values lowercase, added corresponding test case. Also, added changelog to release as soon as this PR will be merged.