### PR TITLE
fix: multipart request body parsing

### DIFF
--- a/src/main/java/com/artipie/http/rq/multipart/State.java
+++ b/src/main/java/com/artipie/http/rq/multipart/State.java
@@ -137,6 +137,14 @@ final class State {
     }
 
     /**
+     * Is in initial state.
+     * @return True if current state is initial
+     */
+    boolean isInit() {
+        return (this.flags & State.INIT) == State.INIT;
+    }
+
+    /**
      * Check if state is in start of the part.
      * @return True if in start
      */


### PR DESCRIPTION
Fix #380 by emmiting empty buffer to body downstrea publisher
if upstream was completed without delivering any chunk.

Fix #381 by prepanding initial chunk with `\r\n` to pass
preamble validation by emitting empty preamble to tokenizer.