### PR TITLE
test(multipart): integration test for multipart

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@ SOFTWARE.
     <dependency>
       <groupId>wtf.g4s8</groupId>
       <artifactId>mime</artifactId>
-      <version>v2.2</version>
+      <version>v2.3.2+java8</version>
     </dependency>
     <!-- Test only dependencies -->
     <dependency>
@@ -194,6 +194,17 @@ SOFTWARE.
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <version>4.5.13</version>
+    </dependency>
+    <!-- integration tests -->
+    <dependency>
+      <groupId>org.apache.httpcomponents.client5</groupId>
+      <artifactId>httpclient5</artifactId>
+      <version>5.1.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents.client5</groupId>
+      <artifactId>httpclient5-fluent</artifactId>
+      <version>5.1.2</version>
     </dependency>
   </dependencies>
   <build>

--- a/src/main/java/com/artipie/http/rq/multipart/MultiPart.java
+++ b/src/main/java/com/artipie/http/rq/multipart/MultiPart.java
@@ -19,6 +19,7 @@ import org.reactivestreams.Subscription;
 /**
  * Multipart request part.
  * @since 1.0
+ * @checkstyle MethodBodyCommentsCheck (500 lines)
  */
 @SuppressWarnings("PMD.NullAssignment")
 final class MultiPart implements RqMultipart.Part, ByteBufferTokenizer.Receiver, Subscription {
@@ -189,6 +190,7 @@ final class MultiPart implements RqMultipart.Part, ByteBufferTokenizer.Receiver,
                 this.nextChunk(chunk);
             } else {
                 this.tokenizer.push(chunk);
+                // head flag could be changed to true after processing chunk
                 if (this.head) {
                     this.tokenizer.close();
                 }

--- a/src/test/java/com/artipie/http/rq/multipart/MultiPartTest.java
+++ b/src/test/java/com/artipie/http/rq/multipart/MultiPartTest.java
@@ -35,14 +35,6 @@ final class MultiPartTest {
                     "\": \"b", "ar\", ", "\"val\": [4]}"
                 )) {
                     part.push(ByteBuffer.wrap(chunk.getBytes(StandardCharsets.US_ASCII)));
-                    try {
-                        // @checkstyle MagicNumberCheck (1 line)
-                        Thread.sleep(100L);
-                    } catch (final InterruptedException ignore) {
-                        Thread.currentThread().interrupt();
-                        part.cancel();
-                        return;
-                    }
                 }
                 part.flush();
             }

--- a/src/test/java/com/artipie/http/rq/multipart/MultipartITCase.java
+++ b/src/test/java/com/artipie/http/rq/multipart/MultipartITCase.java
@@ -31,7 +31,6 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 
@@ -155,10 +154,11 @@ final class MultipartITCase {
                 )
             )
         );
-        final byte[] buf = new byte[1024*17];
+        // @checkstyle MagicNumberCheck (1 line)
+        final byte[] buf = new byte[2048 * 17];
         final byte[] chunk = "0123456789ABCDEF\n".getBytes(StandardCharsets.US_ASCII);
-        for (int i = 0; i < buf.length; i += chunk.length) {
-            System.arraycopy(chunk, 0, buf, i, chunk.length);
+        for (int pos = 0; pos < buf.length; pos += chunk.length) {
+            System.arraycopy(chunk, 0, buf, pos, chunk.length);
         }
         try (CloseableHttpClient cli = HttpClients.createDefault()) {
             final HttpPost post = new HttpPost(String.format("http://localhost:%d/", this.port));
@@ -177,7 +177,9 @@ final class MultipartITCase {
             }
         }
         MatcherAssert.assertThat(
-            "content data should be parsed correctly", result.get(), Matchers.equalTo(new String(buf, StandardCharsets.US_ASCII))
+            "content data should be parsed correctly",
+            result.get(),
+            Matchers.equalTo(new String(buf, StandardCharsets.US_ASCII))
         );
     }
 

--- a/src/test/java/com/artipie/http/rq/multipart/MultipartITCase.java
+++ b/src/test/java/com/artipie/http/rq/multipart/MultipartITCase.java
@@ -1,0 +1,163 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/http/blob/master/LICENSE.txt
+ */
+package com.artipie.http.rq.multipart;
+
+import com.artipie.asto.ext.PublisherAs;
+import com.artipie.http.Headers;
+import com.artipie.http.Response;
+import com.artipie.http.Slice;
+import com.artipie.http.async.AsyncResponse;
+import com.artipie.http.headers.ContentDisposition;
+import com.artipie.http.rs.RsStatus;
+import com.artipie.http.rs.RsWithBody;
+import com.artipie.http.rs.RsWithStatus;
+import com.artipie.http.rs.StandardRs;
+import com.artipie.vertx.VertxSliceServer;
+import io.reactivex.Flowable;
+import io.vertx.reactivex.core.Vertx;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Map.Entry;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Publisher;
+
+/**
+ * Integration tests for multipart feature.
+ * @since 1.2
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ */
+final class MultipartITCase {
+
+    /**
+     * Vertx instance.
+     */
+    private Vertx vertx;
+
+    /**
+     * Vertx slice server instance.
+     */
+    private VertxSliceServer server;
+
+    /**
+     * Server port.
+     */
+    private int port;
+
+    /**
+     * Container for slice.
+     */
+    private SliceContainer container;
+
+    @BeforeEach
+    void init() throws Exception {
+        this.vertx = Vertx.vertx();
+        this.container = new SliceContainer();
+        this.server = new VertxSliceServer(this.vertx, this.container);
+        this.port = this.server.start();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        this.server.stop();
+        this.server.close();
+        this.vertx.close();
+    }
+
+    @Test
+    @SuppressWarnings("PMD.AvoidDuplicateLiterals")
+    void parseMultiparRequest() throws Exception {
+        final AtomicReference<String> result = new AtomicReference<>();
+        this.container.deploy(
+            (line, headers, body) -> new AsyncResponse(
+                new PublisherAs(
+                    Flowable.fromPublisher(
+                        new RqMultipart(new Headers.From(headers), body).inspect(
+                            (part, sink) -> {
+                                final ContentDisposition cds =
+                                    new ContentDisposition(part.headers());
+                                if (cds.fieldName().equals("content")) {
+                                    sink.accept(part);
+                                } else {
+                                    sink.ignore(part);
+                                }
+                                final CompletableFuture<Void> res = new CompletableFuture<>();
+                                res.complete(null);
+                                return res;
+                            }
+                        )
+                    ).flatMap(part -> part)
+                ).asciiString().thenAccept(result::set).thenApply(
+                    none -> StandardRs.OK
+                )
+            )
+        );
+        final String data = "hello-multipart";
+        try (CloseableHttpClient cli = HttpClients.createDefault()) {
+            final HttpPost post = new HttpPost(String.format("http://localhost:%d/", this.port));
+            post.setEntity(
+                MultipartEntityBuilder.create()
+                    .addTextBody("name", "test-data")
+                    .addTextBody("content", data)
+                    .addTextBody("foo", "bar")
+                    .build()
+            );
+            try (CloseableHttpResponse rsp = cli.execute(post)) {
+                MatcherAssert.assertThat(
+                    // @checkstyle MagicNumberCheck (1 line)
+                    "code should be 200", rsp.getCode(), Matchers.equalTo(200)
+                );
+            }
+        }
+        MatcherAssert.assertThat(
+            "content data should be parsed correctly", result.get(), Matchers.equalTo(data)
+        );
+    }
+
+    /**
+     * Container for slice with dynamic deployment.
+     * @since 1.2
+     * @checkstyle ReturnCountCheck (100 lines)
+     */
+    private static final class SliceContainer implements Slice {
+
+        /**
+         * Target slice.
+         */
+        private volatile Slice target;
+
+        @Override
+        @SuppressWarnings("PMD.OnlyOneReturn")
+        public Response response(final String line,
+            final Iterable<Entry<String, String>> headers,
+            final Publisher<ByteBuffer> body) {
+            if (this.target == null) {
+                return new RsWithBody(
+                    new RsWithStatus(RsStatus.UNAVAILABLE),
+                    "target is not set", StandardCharsets.US_ASCII
+                );
+            }
+            return this.target.response(line, headers, body);
+        }
+
+        /**
+         * Deploy slice to container.
+         * @param slice Deployment
+         */
+        void deploy(final Slice slice) {
+            this.target = slice;
+        }
+    }
+}

--- a/src/test/java/com/artipie/http/rq/multipart/StateTest.java
+++ b/src/test/java/com/artipie/http/rq/multipart/StateTest.java
@@ -1,0 +1,24 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/http/blob/master/LICENSE.txt
+ */
+package com.artipie.http.rq.multipart;
+
+import java.nio.ByteBuffer;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link State}.
+ * @since 1.1
+ */
+final class StateTest {
+    @Test
+    void initOnlyOnFirstCall() {
+        final State state = new State();
+        MatcherAssert.assertThat("should be in init state", state.isInit(), Matchers.is(true));
+        state.patch(ByteBuffer.allocate(0), false);
+        MatcherAssert.assertThat("should be not in init state", state.isInit(), Matchers.is(false));
+    }
+}


### PR DESCRIPTION
Add integration test for multipart using Vertx server deployment
and apache-httpclient as client. The test sends request with multipart
body and slice handler parses this request and save expected part body,
then test compares expected part with data sent.

Fixed the problem discovered during testing: some clients don't respect
`RFC6838` specification of media types by expecting **case-sensitive**
mime-type param values for boundary param (it's not case sensitive by spec).
To fix this, the feature g4s8/mime#36 was added to mime-type parser and
a new version v2.3.0 was released.

Close: #420