### PR TITLE
Update http module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,12 +138,6 @@ SOFTWARE.
     </dependency>
 
     <dependency>
-      <groupId>org.reactivestreams</groupId>
-      <artifactId>reactive-streams-tck</artifactId>
-      <version>1.0.3</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-web-client</artifactId>
       <scope>test</scope>
@@ -199,9 +193,13 @@ SOFTWARE.
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.reactivestreams</groupId>
+      <artifactId>reactive-streams-tck</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
-      <version>7.5</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -227,76 +225,6 @@ SOFTWARE.
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <configuration>
-          <output>file</output>
-        </configuration>
-        <executions>
-          <execution>
-            <id>jacoco-initialize</id>
-            <goals>
-              <goal>prepare-agent</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>jacoco-check</id>
-            <phase>test</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-            <configuration>
-              <rules>
-                <rule>
-                  <element>BUNDLE</element>
-                  <!--
- @todo #144:30min Improve code coverage by writing unit-tests:
-  each coverage counter should not be less than 75. Write unit-tests
-  to achieve such coverage. After each iteration do not forget to
-  correct coverage minimums and this todo to continue work.
--->
-                  <limits>
-                    <limit>
-                      <counter>INSTRUCTION</counter>
-                      <value>COVEREDRATIO</value>
-                      <minimum>0.72</minimum>
-                    </limit>
-                    <limit>
-                      <counter>LINE</counter>
-                      <value>COVEREDRATIO</value>
-                      <minimum>0.68</minimum>
-                    </limit>
-                    <limit>
-                      <counter>BRANCH</counter>
-                      <value>COVEREDRATIO</value>
-                      <minimum>0.52</minimum>
-                    </limit>
-                    <limit>
-                      <counter>COMPLEXITY</counter>
-                      <value>COVEREDRATIO</value>
-                      <minimum>0.61</minimum>
-                    </limit>
-                    <limit>
-                      <counter>METHOD</counter>
-                      <value>COVEREDRATIO</value>
-                      <minimum>0.65</minimum>
-                    </limit>
-                    <limit>
-                      <counter>CLASS</counter>
-                      <value>MISSEDCOUNT</value>
-                      <maximum>26</maximum>
-                    </limit>
-                  </limits>
-                </rule>
-              </rules>
-            </configuration>
-          </execution>
-          <execution>
-            <id>jacoco-site</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>report</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,12 @@ SOFTWARE.
 
   <dependencies>
     <dependency>
+      <groupId>com.artipie</groupId>
+      <artifactId>asto</artifactId>
+      <version>v1.11.0</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.reactivestreams</groupId>
       <artifactId>reactive-streams</artifactId>
     </dependency>
@@ -92,24 +98,12 @@ SOFTWARE.
       <artifactId>rxjava2-jdk8-interop</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.json</groupId>
-      <artifactId>javax.json-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.artipie</groupId>
-      <artifactId>asto</artifactId>
-      <version>v1.11.0</version>
-    </dependency>
-    <dependency>
       <groupId>org.cqfn</groupId>
       <artifactId>rio</artifactId>
-      <version>0.3</version>
     </dependency>
     <dependency>
       <groupId>wtf.g4s8</groupId>
       <artifactId>mime</artifactId>
-      <version>v2.3.2+java8</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents.core5</groupId>
@@ -122,7 +116,27 @@ SOFTWARE.
       <version>5.1.3</version>
     </dependency>
 
+    <!-- provided servlet deps for wrappers -->
+    <dependency>
+      <groupId>javax.json</groupId>
+      <artifactId>javax.json-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>4.0.1</version>
+      <scope>provided</scope>
+    </dependency>
+
     <!-- Test only dependencies -->
+    <dependency>
+      <groupId>com.artipie</groupId>
+      <artifactId>vertx-server</artifactId>
+      <version>1.0.0</version>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>org.reactivestreams</groupId>
       <artifactId>reactive-streams-tck</artifactId>
@@ -132,12 +146,6 @@ SOFTWARE.
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-web-client</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.artipie</groupId>
-      <artifactId>vertx-server</artifactId>
-      <version>1.0.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -153,7 +161,6 @@ SOFTWARE.
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
-      <version>${junit-platform.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -167,13 +174,6 @@ SOFTWARE.
       <artifactId>javax.json</artifactId>
       <version>${javax.json.version}</version>
       <scope>test</scope>
-    </dependency>
-    <!-- provided servlet deps for wrappers -->
-    <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>4.0.1</version>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
@@ -198,7 +198,12 @@ SOFTWARE.
       <artifactId>commons-lang3</artifactId>
       <scope>test</scope>
     </dependency>
-    <!-- integration tests -->
+    <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+      <version>7.5</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -208,49 +213,16 @@ SOFTWARE.
         <artifactId>maven-surefire-plugin</artifactId>
         <dependencies>
           <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.8.1</version>
+            <groupId>org.apache.maven.surefire</groupId>
+            <artifactId>surefire-junit-platform</artifactId>
+            <version>${surefire.version}</version>
           </dependency>
           <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
-            <version>7.4.0</version>
+            <groupId>org.apache.maven.surefire</groupId>
+            <artifactId>surefire-testng</artifactId>
+            <version>${surefire.version}</version>
           </dependency>
         </dependencies>
-        <executions>
-          <!-- FIXME: reactive TCK tests are not executed for multipart processor -->
-          <!-- <execution> -->
-          <!--   <id>surefire-testng</id> -->
-          <!--   <phase>test</phase> -->
-          <!--   <goals> -->
-          <!--     <goal>test</goal> -->
-          <!--   </goals> -->
-          <!--   <configuration> -->
-          <!--     <skip>false</skip> -->
-          <!--     <includes> -->
-          <!--       <include>com.artipie.http.rq.multipart.MultipartTckTest</include> -->
-          <!--       <include>com.artipie.http.rq.multipart.MultipartsTckTest</include> -->
-          <!--     </includes> -->
-          <!--     <junitArtifactName>none:none</junitArtifactName> -->
-          <!--   </configuration> -->
-          <!-- </execution> -->
-          <execution>
-            <id>surefire-junit</id>
-            <phase>test</phase>
-            <goals>
-              <goal>test</goal>
-            </goals>
-            <configuration>
-              <skip>false</skip>
-              <excludes>
-                <exclude>com.artipie.http.rq.multipart.MultipartTckTest</exclude>
-                <exclude>com.artipie.http.rq.multipart.MultipartsTckTest</exclude>
-              </excludes>
-              <testNGArtifactName>none:none</testNGArtifactName>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <groupId>org.jacoco</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -24,28 +24,35 @@ SOFTWARE.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <groupId>com.artipie</groupId>
     <artifactId>ppom</artifactId>
-    <version>1.1.0</version>
+    <version>2.0-SNAPSHOT</version>
+    <relativePath/>
   </parent>
+
   <artifactId>http</artifactId>
   <version>2.0-SNAPSHOT</version>
-  <name>Artipie HTTP</name>
-  <url>https://github.com/artipie/http</url>
+
+  <name>${project.groupId}:${project.artifactId}</name>
   <description>HTTP layer of Artipie</description>
+  <url>https://github.com/artipie/http</url>
+
   <licenses>
     <license>
       <name>MIT License</name>
       <url>https://github.com/artipie/http/blob/master/LICENSE.txt</url>
     </license>
   </licenses>
+
   <developers>
     <developer>
       <name>Kirill Che.</name>
       <email>g4s8.public@gmail.com</email>
     </developer>
   </developers>
+
   <contributors>
     <contributor>
       <name>Olivier B. OURA</name>
@@ -58,33 +65,31 @@ SOFTWARE.
       <timezone>+0</timezone>
     </contributor>
   </contributors>
+
   <scm>
     <connection>scm:git:git://github.com/artipie/http.git</connection>
     <developerConnection>scm:git:ssh://github.com:artipie/http.git</developerConnection>
     <url>https://github.com/artipie/http/tree/master</url>
   </scm>
+
   <properties>
+    <maven.compiler.release>17</maven.compiler.release>
+
     <qulice.license>${project.basedir}/LICENSE.header</qulice.license>
-    <surefire.version>3.0.0-M5</surefire.version>
   </properties>
+
   <dependencies>
     <dependency>
-      <groupId>com.github.akarnokd</groupId>
-      <artifactId>rxjava2-jdk8-interop</artifactId>
+      <groupId>org.reactivestreams</groupId>
+      <artifactId>reactive-streams</artifactId>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>
-      <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-collections4</artifactId>
-      <version>4.4</version>
+      <groupId>com.github.akarnokd</groupId>
+      <artifactId>rxjava2-jdk8-interop</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.json</groupId>
@@ -106,13 +111,18 @@ SOFTWARE.
       <artifactId>mime</artifactId>
       <version>v2.3.2+java8</version>
     </dependency>
-    <!-- Test only dependencies -->
     <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-      <version>4.5.13</version>
-      <scope>test</scope>
+      <groupId>org.apache.httpcomponents.core5</groupId>
+      <artifactId>httpcore5</artifactId>
+      <version>5.1.3</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents.client5</groupId>
+      <artifactId>httpclient5</artifactId>
+      <version>5.1.3</version>
+    </dependency>
+
+    <!-- Test only dependencies -->
     <dependency>
       <groupId>org.reactivestreams</groupId>
       <artifactId>reactive-streams-tck</artifactId>
@@ -122,7 +132,6 @@ SOFTWARE.
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-web-client</artifactId>
-      <version>4.2.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -133,18 +142,12 @@ SOFTWARE.
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
-      <version>1.7.32</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -165,7 +168,7 @@ SOFTWARE.
       <version>${javax.json.version}</version>
       <scope>test</scope>
     </dependency>
-    <!-- provided serlet deps for wrappers -->
+    <!-- provided servlet deps for wrappers -->
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
@@ -191,28 +194,18 @@ SOFTWARE.
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-      <version>4.5.13</version>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <scope>test</scope>
     </dependency>
     <!-- integration tests -->
-    <dependency>
-      <groupId>org.apache.httpcomponents.client5</groupId>
-      <artifactId>httpclient5</artifactId>
-      <version>5.1.2</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents.client5</groupId>
-      <artifactId>httpclient5-fluent</artifactId>
-      <version>5.1.3</version>
-    </dependency>
   </dependencies>
+
   <build>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${surefire.version}</version>
         <dependencies>
           <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -262,7 +255,6 @@ SOFTWARE.
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.7</version>
         <configuration>
           <output>file</output>
         </configuration>
@@ -335,44 +327,9 @@ SOFTWARE.
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <configuration>
-          <!-- <parallel>none</parallel> -->
-          <trimStackTrace>false</trimStackTrace>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>integration-test</goal>
-              <goal>verify</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
-  <profiles>
-    <profile>
-      <id>skip-itcases-old-jdk</id>
-      <activation>
-        <jdk>1.8</jdk>
-      </activation>
-      <build>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-compiler-plugin</artifactId>
-              <configuration>
-                <testExcludes>
-                  <exclude>**/com/artipie/http/servlet/**</exclude>
-                  <exclude>**/com/artipie/http/slice/SliceITCase.java</exclude>
-                </testExcludes>
-              </configuration>
-            </plugin>
-          </plugins>
-        </pluginManagement>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/src/main/java/com/artipie/http/servlet/ServletSliceWrap.java
+++ b/src/main/java/com/artipie/http/servlet/ServletSliceWrap.java
@@ -22,8 +22,9 @@ import java.util.stream.Collectors;
 import javax.servlet.AsyncContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.apache.http.HttpStatus;
-import org.apache.http.client.utils.URIBuilder;
+
+import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.net.URIBuilder;
 import org.cqfn.rio.Buffers;
 import org.cqfn.rio.stream.ReactiveInputStream;
 

--- a/src/main/java/com/artipie/http/slice/TrimPathSlice.java
+++ b/src/main/java/com/artipie/http/slice/TrimPathSlice.java
@@ -22,7 +22,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.apache.http.client.utils.URIBuilder;
+
+import org.apache.hc.core5.net.URIBuilder;
 import org.reactivestreams.Publisher;
 
 /**

--- a/src/test/java/com/artipie/http/rq/multipart/MultiPartsTckTest.java
+++ b/src/test/java/com/artipie/http/rq/multipart/MultiPartsTckTest.java
@@ -33,6 +33,13 @@ public final class MultiPartsTckTest extends PublisherVerification<Integer> {
     private final TestEnvironment env;
 
     /**
+     * Ctor.
+     */
+    public MultiPartsTckTest() {
+        this(new TestEnvironment());
+    }
+
+    /**
      * Primary ctor.
      * @param env Tets environemnt
      */


### PR DESCRIPTION
Settle on httpclient5 instead on both,
use new parent, remove unused cruft and
deps. Use as much as possible from parent POM.

Depends on https://github.com/artipie/ppom/pull/103