### PR TITLE
chore: increase license year to 2022

### DIFF
--- a/LICENSE.header
+++ b/LICENSE.header
@@ -1,2 +1,2 @@
-The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
 https://github.com/artipie/http/blob/master/LICENSE.txt

--- a/src/main/java/com/artipie/http/ArtipieHttpException.java
+++ b/src/main/java/com/artipie/http/ArtipieHttpException.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http;

--- a/src/main/java/com/artipie/http/Connection.java
+++ b/src/main/java/com/artipie/http/Connection.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http;

--- a/src/main/java/com/artipie/http/Headers.java
+++ b/src/main/java/com/artipie/http/Headers.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http;

--- a/src/main/java/com/artipie/http/Response.java
+++ b/src/main/java/com/artipie/http/Response.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http;

--- a/src/main/java/com/artipie/http/Slice.java
+++ b/src/main/java/com/artipie/http/Slice.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http;

--- a/src/main/java/com/artipie/http/async/AsyncResponse.java
+++ b/src/main/java/com/artipie/http/async/AsyncResponse.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.async;

--- a/src/main/java/com/artipie/http/async/AsyncSlice.java
+++ b/src/main/java/com/artipie/http/async/AsyncSlice.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 

--- a/src/main/java/com/artipie/http/async/package-info.java
+++ b/src/main/java/com/artipie/http/async/package-info.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 

--- a/src/main/java/com/artipie/http/auth/Action.java
+++ b/src/main/java/com/artipie/http/auth/Action.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.auth;

--- a/src/main/java/com/artipie/http/auth/AuthScheme.java
+++ b/src/main/java/com/artipie/http/auth/AuthScheme.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.auth;

--- a/src/main/java/com/artipie/http/auth/AuthSlice.java
+++ b/src/main/java/com/artipie/http/auth/AuthSlice.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.auth;

--- a/src/main/java/com/artipie/http/auth/Authentication.java
+++ b/src/main/java/com/artipie/http/auth/Authentication.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.auth;

--- a/src/main/java/com/artipie/http/auth/BasicAuthScheme.java
+++ b/src/main/java/com/artipie/http/auth/BasicAuthScheme.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.auth;

--- a/src/main/java/com/artipie/http/auth/BasicAuthSlice.java
+++ b/src/main/java/com/artipie/http/auth/BasicAuthSlice.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.auth;

--- a/src/main/java/com/artipie/http/auth/BasicIdentities.java
+++ b/src/main/java/com/artipie/http/auth/BasicIdentities.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.auth;

--- a/src/main/java/com/artipie/http/auth/BearerAuthScheme.java
+++ b/src/main/java/com/artipie/http/auth/BearerAuthScheme.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.auth;

--- a/src/main/java/com/artipie/http/auth/Identities.java
+++ b/src/main/java/com/artipie/http/auth/Identities.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.auth;

--- a/src/main/java/com/artipie/http/auth/JoinedPermissions.java
+++ b/src/main/java/com/artipie/http/auth/JoinedPermissions.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.auth;

--- a/src/main/java/com/artipie/http/auth/Permission.java
+++ b/src/main/java/com/artipie/http/auth/Permission.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.auth;

--- a/src/main/java/com/artipie/http/auth/Permissions.java
+++ b/src/main/java/com/artipie/http/auth/Permissions.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.auth;

--- a/src/main/java/com/artipie/http/auth/SliceAuth.java
+++ b/src/main/java/com/artipie/http/auth/SliceAuth.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.auth;

--- a/src/main/java/com/artipie/http/auth/TokenAuthentication.java
+++ b/src/main/java/com/artipie/http/auth/TokenAuthentication.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.auth;

--- a/src/main/java/com/artipie/http/auth/package-info.java
+++ b/src/main/java/com/artipie/http/auth/package-info.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 

--- a/src/main/java/com/artipie/http/group/GroupConnection.java
+++ b/src/main/java/com/artipie/http/group/GroupConnection.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.group;

--- a/src/main/java/com/artipie/http/group/GroupResponse.java
+++ b/src/main/java/com/artipie/http/group/GroupResponse.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.group;

--- a/src/main/java/com/artipie/http/group/GroupResult.java
+++ b/src/main/java/com/artipie/http/group/GroupResult.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.group;

--- a/src/main/java/com/artipie/http/group/GroupResults.java
+++ b/src/main/java/com/artipie/http/group/GroupResults.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.group;

--- a/src/main/java/com/artipie/http/group/GroupSlice.java
+++ b/src/main/java/com/artipie/http/group/GroupSlice.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.group;

--- a/src/main/java/com/artipie/http/group/package-info.java
+++ b/src/main/java/com/artipie/http/group/package-info.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 

--- a/src/main/java/com/artipie/http/headers/Accept.java
+++ b/src/main/java/com/artipie/http/headers/Accept.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.headers;

--- a/src/main/java/com/artipie/http/headers/Authorization.java
+++ b/src/main/java/com/artipie/http/headers/Authorization.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.headers;

--- a/src/main/java/com/artipie/http/headers/ContentDisposition.java
+++ b/src/main/java/com/artipie/http/headers/ContentDisposition.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.headers;

--- a/src/main/java/com/artipie/http/headers/ContentFileName.java
+++ b/src/main/java/com/artipie/http/headers/ContentFileName.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.headers;

--- a/src/main/java/com/artipie/http/headers/ContentLength.java
+++ b/src/main/java/com/artipie/http/headers/ContentLength.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.headers;

--- a/src/main/java/com/artipie/http/headers/ContentType.java
+++ b/src/main/java/com/artipie/http/headers/ContentType.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.headers;

--- a/src/main/java/com/artipie/http/headers/Header.java
+++ b/src/main/java/com/artipie/http/headers/Header.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.headers;

--- a/src/main/java/com/artipie/http/headers/Location.java
+++ b/src/main/java/com/artipie/http/headers/Location.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.headers;

--- a/src/main/java/com/artipie/http/headers/WwwAuthenticate.java
+++ b/src/main/java/com/artipie/http/headers/WwwAuthenticate.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.headers;

--- a/src/main/java/com/artipie/http/headers/package-info.java
+++ b/src/main/java/com/artipie/http/headers/package-info.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 

--- a/src/main/java/com/artipie/http/hm/AssertSlice.java
+++ b/src/main/java/com/artipie/http/hm/AssertSlice.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.hm;

--- a/src/main/java/com/artipie/http/hm/IsHeader.java
+++ b/src/main/java/com/artipie/http/hm/IsHeader.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.hm;

--- a/src/main/java/com/artipie/http/hm/IsJson.java
+++ b/src/main/java/com/artipie/http/hm/IsJson.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.hm;

--- a/src/main/java/com/artipie/http/hm/IsString.java
+++ b/src/main/java/com/artipie/http/hm/IsString.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.hm;

--- a/src/main/java/com/artipie/http/hm/ResponseMatcher.java
+++ b/src/main/java/com/artipie/http/hm/ResponseMatcher.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.hm;

--- a/src/main/java/com/artipie/http/hm/RqHasHeader.java
+++ b/src/main/java/com/artipie/http/hm/RqHasHeader.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.hm;

--- a/src/main/java/com/artipie/http/hm/RqLineHasUri.java
+++ b/src/main/java/com/artipie/http/hm/RqLineHasUri.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.hm;

--- a/src/main/java/com/artipie/http/hm/RsHasBody.java
+++ b/src/main/java/com/artipie/http/hm/RsHasBody.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 

--- a/src/main/java/com/artipie/http/hm/RsHasHeaders.java
+++ b/src/main/java/com/artipie/http/hm/RsHasHeaders.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 

--- a/src/main/java/com/artipie/http/hm/RsHasStatus.java
+++ b/src/main/java/com/artipie/http/hm/RsHasStatus.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 

--- a/src/main/java/com/artipie/http/hm/SliceHasResponse.java
+++ b/src/main/java/com/artipie/http/hm/SliceHasResponse.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.hm;

--- a/src/main/java/com/artipie/http/hm/package-info.java
+++ b/src/main/java/com/artipie/http/hm/package-info.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 

--- a/src/main/java/com/artipie/http/misc/BufAccumulator.java
+++ b/src/main/java/com/artipie/http/misc/BufAccumulator.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.misc;

--- a/src/main/java/com/artipie/http/misc/ByteBufferTokenizer.java
+++ b/src/main/java/com/artipie/http/misc/ByteBufferTokenizer.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.misc;

--- a/src/main/java/com/artipie/http/misc/DummySubscription.java
+++ b/src/main/java/com/artipie/http/misc/DummySubscription.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.misc;

--- a/src/main/java/com/artipie/http/misc/Pipeline.java
+++ b/src/main/java/com/artipie/http/misc/Pipeline.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.misc;

--- a/src/main/java/com/artipie/http/misc/RandomFreePort.java
+++ b/src/main/java/com/artipie/http/misc/RandomFreePort.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.misc;

--- a/src/main/java/com/artipie/http/misc/TokenizerFlatProc.java
+++ b/src/main/java/com/artipie/http/misc/TokenizerFlatProc.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.misc;

--- a/src/main/java/com/artipie/http/misc/package-info.java
+++ b/src/main/java/com/artipie/http/misc/package-info.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 

--- a/src/main/java/com/artipie/http/package-info.java
+++ b/src/main/java/com/artipie/http/package-info.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 

--- a/src/main/java/com/artipie/http/rq/RequestLine.java
+++ b/src/main/java/com/artipie/http/rq/RequestLine.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.rq;

--- a/src/main/java/com/artipie/http/rq/RequestLineFrom.java
+++ b/src/main/java/com/artipie/http/rq/RequestLineFrom.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 

--- a/src/main/java/com/artipie/http/rq/RequestLinePrefix.java
+++ b/src/main/java/com/artipie/http/rq/RequestLinePrefix.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.rq;

--- a/src/main/java/com/artipie/http/rq/RqHeaders.java
+++ b/src/main/java/com/artipie/http/rq/RqHeaders.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.rq;

--- a/src/main/java/com/artipie/http/rq/RqMethod.java
+++ b/src/main/java/com/artipie/http/rq/RqMethod.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.rq;

--- a/src/main/java/com/artipie/http/rq/RqParams.java
+++ b/src/main/java/com/artipie/http/rq/RqParams.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.rq;

--- a/src/main/java/com/artipie/http/rq/multipart/Completion.java
+++ b/src/main/java/com/artipie/http/rq/multipart/Completion.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.rq.multipart;

--- a/src/main/java/com/artipie/http/rq/multipart/EmptyPart.java
+++ b/src/main/java/com/artipie/http/rq/multipart/EmptyPart.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.rq.multipart;

--- a/src/main/java/com/artipie/http/rq/multipart/MultiPart.java
+++ b/src/main/java/com/artipie/http/rq/multipart/MultiPart.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.rq.multipart;

--- a/src/main/java/com/artipie/http/rq/multipart/MultiParts.java
+++ b/src/main/java/com/artipie/http/rq/multipart/MultiParts.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.rq.multipart;

--- a/src/main/java/com/artipie/http/rq/multipart/MultipartHeaders.java
+++ b/src/main/java/com/artipie/http/rq/multipart/MultipartHeaders.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.rq.multipart;

--- a/src/main/java/com/artipie/http/rq/multipart/RqMultipart.java
+++ b/src/main/java/com/artipie/http/rq/multipart/RqMultipart.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 

--- a/src/main/java/com/artipie/http/rq/multipart/State.java
+++ b/src/main/java/com/artipie/http/rq/multipart/State.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.rq.multipart;

--- a/src/main/java/com/artipie/http/rq/multipart/package-info.java
+++ b/src/main/java/com/artipie/http/rq/multipart/package-info.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 

--- a/src/main/java/com/artipie/http/rq/package-info.java
+++ b/src/main/java/com/artipie/http/rq/package-info.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 

--- a/src/main/java/com/artipie/http/rs/CachedResponse.java
+++ b/src/main/java/com/artipie/http/rs/CachedResponse.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.rs;

--- a/src/main/java/com/artipie/http/rs/RsFull.java
+++ b/src/main/java/com/artipie/http/rs/RsFull.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 

--- a/src/main/java/com/artipie/http/rs/RsStatus.java
+++ b/src/main/java/com/artipie/http/rs/RsStatus.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.rs;

--- a/src/main/java/com/artipie/http/rs/RsWithBody.java
+++ b/src/main/java/com/artipie/http/rs/RsWithBody.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 

--- a/src/main/java/com/artipie/http/rs/RsWithHeaders.java
+++ b/src/main/java/com/artipie/http/rs/RsWithHeaders.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 

--- a/src/main/java/com/artipie/http/rs/RsWithStatus.java
+++ b/src/main/java/com/artipie/http/rs/RsWithStatus.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 

--- a/src/main/java/com/artipie/http/rs/StandardRs.java
+++ b/src/main/java/com/artipie/http/rs/StandardRs.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.rs;

--- a/src/main/java/com/artipie/http/rs/common/RsError.java
+++ b/src/main/java/com/artipie/http/rs/common/RsError.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.rs.common;

--- a/src/main/java/com/artipie/http/rs/common/RsJson.java
+++ b/src/main/java/com/artipie/http/rs/common/RsJson.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.rs.common;

--- a/src/main/java/com/artipie/http/rs/common/RsText.java
+++ b/src/main/java/com/artipie/http/rs/common/RsText.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.rs.common;

--- a/src/main/java/com/artipie/http/rs/common/package-info.java
+++ b/src/main/java/com/artipie/http/rs/common/package-info.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 

--- a/src/main/java/com/artipie/http/rs/package-info.java
+++ b/src/main/java/com/artipie/http/rs/package-info.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 

--- a/src/main/java/com/artipie/http/rt/ByMethodsRule.java
+++ b/src/main/java/com/artipie/http/rt/ByMethodsRule.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.rt;

--- a/src/main/java/com/artipie/http/rt/RtPath.java
+++ b/src/main/java/com/artipie/http/rt/RtPath.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.rt;

--- a/src/main/java/com/artipie/http/rt/RtRule.java
+++ b/src/main/java/com/artipie/http/rt/RtRule.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.rt;

--- a/src/main/java/com/artipie/http/rt/RtRulePath.java
+++ b/src/main/java/com/artipie/http/rt/RtRulePath.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.rt;

--- a/src/main/java/com/artipie/http/rt/SliceRoute.java
+++ b/src/main/java/com/artipie/http/rt/SliceRoute.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.rt;

--- a/src/main/java/com/artipie/http/rt/package-info.java
+++ b/src/main/java/com/artipie/http/rt/package-info.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 

--- a/src/main/java/com/artipie/http/servlet/ServletConnection.java
+++ b/src/main/java/com/artipie/http/servlet/ServletConnection.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 

--- a/src/main/java/com/artipie/http/servlet/ServletSliceWrap.java
+++ b/src/main/java/com/artipie/http/servlet/ServletSliceWrap.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 

--- a/src/main/java/com/artipie/http/servlet/package-info.java
+++ b/src/main/java/com/artipie/http/servlet/package-info.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 

--- a/src/main/java/com/artipie/http/slice/ContentWithSize.java
+++ b/src/main/java/com/artipie/http/slice/ContentWithSize.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.slice;

--- a/src/main/java/com/artipie/http/slice/GzipSlice.java
+++ b/src/main/java/com/artipie/http/slice/GzipSlice.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.slice;

--- a/src/main/java/com/artipie/http/slice/HeadSlice.java
+++ b/src/main/java/com/artipie/http/slice/HeadSlice.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.slice;

--- a/src/main/java/com/artipie/http/slice/KeyFromPath.java
+++ b/src/main/java/com/artipie/http/slice/KeyFromPath.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.slice;

--- a/src/main/java/com/artipie/http/slice/ListingFormat.java
+++ b/src/main/java/com/artipie/http/slice/ListingFormat.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 

--- a/src/main/java/com/artipie/http/slice/LoggingSlice.java
+++ b/src/main/java/com/artipie/http/slice/LoggingSlice.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.slice;

--- a/src/main/java/com/artipie/http/slice/SliceDelete.java
+++ b/src/main/java/com/artipie/http/slice/SliceDelete.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 

--- a/src/main/java/com/artipie/http/slice/SliceDownload.java
+++ b/src/main/java/com/artipie/http/slice/SliceDownload.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.slice;

--- a/src/main/java/com/artipie/http/slice/SliceListing.java
+++ b/src/main/java/com/artipie/http/slice/SliceListing.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.slice;

--- a/src/main/java/com/artipie/http/slice/SliceOptional.java
+++ b/src/main/java/com/artipie/http/slice/SliceOptional.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.slice;

--- a/src/main/java/com/artipie/http/slice/SliceSimple.java
+++ b/src/main/java/com/artipie/http/slice/SliceSimple.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 

--- a/src/main/java/com/artipie/http/slice/SliceUpload.java
+++ b/src/main/java/com/artipie/http/slice/SliceUpload.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.slice;

--- a/src/main/java/com/artipie/http/slice/SliceWithHeaders.java
+++ b/src/main/java/com/artipie/http/slice/SliceWithHeaders.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.slice;

--- a/src/main/java/com/artipie/http/slice/TrimPathSlice.java
+++ b/src/main/java/com/artipie/http/slice/TrimPathSlice.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.slice;

--- a/src/main/java/com/artipie/http/slice/WithGzipSlice.java
+++ b/src/main/java/com/artipie/http/slice/WithGzipSlice.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.slice;

--- a/src/main/java/com/artipie/http/slice/package-info.java
+++ b/src/main/java/com/artipie/http/slice/package-info.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 

--- a/src/test/java/com/artipie/http/HeadersFromTest.java
+++ b/src/test/java/com/artipie/http/HeadersFromTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http;

--- a/src/test/java/com/artipie/http/async/AsyncResponseTest.java
+++ b/src/test/java/com/artipie/http/async/AsyncResponseTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.async;

--- a/src/test/java/com/artipie/http/async/AsyncSliceTest.java
+++ b/src/test/java/com/artipie/http/async/AsyncSliceTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.async;

--- a/src/test/java/com/artipie/http/async/package-info.java
+++ b/src/test/java/com/artipie/http/async/package-info.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 

--- a/src/test/java/com/artipie/http/auth/ActionTest.java
+++ b/src/test/java/com/artipie/http/auth/ActionTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.auth;

--- a/src/test/java/com/artipie/http/auth/AuthSchemeNoneTest.java
+++ b/src/test/java/com/artipie/http/auth/AuthSchemeNoneTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.auth;

--- a/src/test/java/com/artipie/http/auth/AuthenticationTest.java
+++ b/src/test/java/com/artipie/http/auth/AuthenticationTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.auth;

--- a/src/test/java/com/artipie/http/auth/BasicAuthSliceTest.java
+++ b/src/test/java/com/artipie/http/auth/BasicAuthSliceTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.auth;

--- a/src/test/java/com/artipie/http/auth/BasicIdentitiesTest.java
+++ b/src/test/java/com/artipie/http/auth/BasicIdentitiesTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.auth;

--- a/src/test/java/com/artipie/http/auth/BearerAuthSchemeTest.java
+++ b/src/test/java/com/artipie/http/auth/BearerAuthSchemeTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.auth;

--- a/src/test/java/com/artipie/http/auth/JoinedPermissionsTest.java
+++ b/src/test/java/com/artipie/http/auth/JoinedPermissionsTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.auth;

--- a/src/test/java/com/artipie/http/auth/PermissionAllTest.java
+++ b/src/test/java/com/artipie/http/auth/PermissionAllTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.auth;

--- a/src/test/java/com/artipie/http/auth/PermissionAnyTest.java
+++ b/src/test/java/com/artipie/http/auth/PermissionAnyTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.auth;

--- a/src/test/java/com/artipie/http/auth/PermissionByNameTest.java
+++ b/src/test/java/com/artipie/http/auth/PermissionByNameTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.auth;

--- a/src/test/java/com/artipie/http/auth/PermissionsTest.java
+++ b/src/test/java/com/artipie/http/auth/PermissionsTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.auth;

--- a/src/test/java/com/artipie/http/auth/SliceAuthTest.java
+++ b/src/test/java/com/artipie/http/auth/SliceAuthTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.auth;

--- a/src/test/java/com/artipie/http/auth/package-info.java
+++ b/src/test/java/com/artipie/http/auth/package-info.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 

--- a/src/test/java/com/artipie/http/group/GroupSliceTest.java
+++ b/src/test/java/com/artipie/http/group/GroupSliceTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.group;

--- a/src/test/java/com/artipie/http/group/package-info.java
+++ b/src/test/java/com/artipie/http/group/package-info.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 /**

--- a/src/test/java/com/artipie/http/headers/AcceptTest.java
+++ b/src/test/java/com/artipie/http/headers/AcceptTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.headers;

--- a/src/test/java/com/artipie/http/headers/AuthorizationBasicTest.java
+++ b/src/test/java/com/artipie/http/headers/AuthorizationBasicTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.headers;

--- a/src/test/java/com/artipie/http/headers/AuthorizationBearerTest.java
+++ b/src/test/java/com/artipie/http/headers/AuthorizationBearerTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.headers;

--- a/src/test/java/com/artipie/http/headers/AuthorizationTest.java
+++ b/src/test/java/com/artipie/http/headers/AuthorizationTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.headers;

--- a/src/test/java/com/artipie/http/headers/AuthorizationTokenTest.java
+++ b/src/test/java/com/artipie/http/headers/AuthorizationTokenTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.headers;

--- a/src/test/java/com/artipie/http/headers/ContentDispositionTest.java
+++ b/src/test/java/com/artipie/http/headers/ContentDispositionTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.headers;

--- a/src/test/java/com/artipie/http/headers/ContentFileNameTest.java
+++ b/src/test/java/com/artipie/http/headers/ContentFileNameTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.headers;

--- a/src/test/java/com/artipie/http/headers/ContentLengthTest.java
+++ b/src/test/java/com/artipie/http/headers/ContentLengthTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.headers;

--- a/src/test/java/com/artipie/http/headers/ContentTypeTest.java
+++ b/src/test/java/com/artipie/http/headers/ContentTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.headers;

--- a/src/test/java/com/artipie/http/headers/HeaderTest.java
+++ b/src/test/java/com/artipie/http/headers/HeaderTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 

--- a/src/test/java/com/artipie/http/headers/LocationTest.java
+++ b/src/test/java/com/artipie/http/headers/LocationTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.headers;

--- a/src/test/java/com/artipie/http/headers/WwwAuthenticateTest.java
+++ b/src/test/java/com/artipie/http/headers/WwwAuthenticateTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.headers;

--- a/src/test/java/com/artipie/http/headers/package-info.java
+++ b/src/test/java/com/artipie/http/headers/package-info.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 

--- a/src/test/java/com/artipie/http/hm/IsHeaderTest.java
+++ b/src/test/java/com/artipie/http/hm/IsHeaderTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.hm;

--- a/src/test/java/com/artipie/http/hm/IsJsonTest.java
+++ b/src/test/java/com/artipie/http/hm/IsJsonTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.hm;

--- a/src/test/java/com/artipie/http/hm/IsStringTest.java
+++ b/src/test/java/com/artipie/http/hm/IsStringTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.hm;

--- a/src/test/java/com/artipie/http/hm/ResponseMatcherTest.java
+++ b/src/test/java/com/artipie/http/hm/ResponseMatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.hm;

--- a/src/test/java/com/artipie/http/hm/RsHasBodyTest.java
+++ b/src/test/java/com/artipie/http/hm/RsHasBodyTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.hm;

--- a/src/test/java/com/artipie/http/hm/RsHasHeadersTest.java
+++ b/src/test/java/com/artipie/http/hm/RsHasHeadersTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.hm;

--- a/src/test/java/com/artipie/http/hm/package-info.java
+++ b/src/test/java/com/artipie/http/hm/package-info.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 

--- a/src/test/java/com/artipie/http/misc/BufAccumulatorTest.java
+++ b/src/test/java/com/artipie/http/misc/BufAccumulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.misc;

--- a/src/test/java/com/artipie/http/misc/ByteBufferTokenizerTest.java
+++ b/src/test/java/com/artipie/http/misc/ByteBufferTokenizerTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.misc;

--- a/src/test/java/com/artipie/http/misc/PipelineTest.java
+++ b/src/test/java/com/artipie/http/misc/PipelineTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.misc;

--- a/src/test/java/com/artipie/http/misc/RandomFreePortTest.java
+++ b/src/test/java/com/artipie/http/misc/RandomFreePortTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.misc;

--- a/src/test/java/com/artipie/http/misc/TokenizerFlatProcTest.java
+++ b/src/test/java/com/artipie/http/misc/TokenizerFlatProcTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.misc;

--- a/src/test/java/com/artipie/http/misc/package-info.java
+++ b/src/test/java/com/artipie/http/misc/package-info.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 

--- a/src/test/java/com/artipie/http/package-info.java
+++ b/src/test/java/com/artipie/http/package-info.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 

--- a/src/test/java/com/artipie/http/rq/RequestLineFromTest.java
+++ b/src/test/java/com/artipie/http/rq/RequestLineFromTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 

--- a/src/test/java/com/artipie/http/rq/RequestLinePrefixTest.java
+++ b/src/test/java/com/artipie/http/rq/RequestLinePrefixTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.rq;

--- a/src/test/java/com/artipie/http/rq/RequestLineTest.java
+++ b/src/test/java/com/artipie/http/rq/RequestLineTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.rq;

--- a/src/test/java/com/artipie/http/rq/RqHeadersTest.java
+++ b/src/test/java/com/artipie/http/rq/RqHeadersTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.rq;

--- a/src/test/java/com/artipie/http/rq/RqParamsTest.java
+++ b/src/test/java/com/artipie/http/rq/RqParamsTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.rq;

--- a/src/test/java/com/artipie/http/rq/multipart/MultiPartTckTest.java
+++ b/src/test/java/com/artipie/http/rq/multipart/MultiPartTckTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.rq.multipart;

--- a/src/test/java/com/artipie/http/rq/multipart/MultiPartTest.java
+++ b/src/test/java/com/artipie/http/rq/multipart/MultiPartTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.rq.multipart;

--- a/src/test/java/com/artipie/http/rq/multipart/MultiPartsTckTest.java
+++ b/src/test/java/com/artipie/http/rq/multipart/MultiPartsTckTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.rq.multipart;

--- a/src/test/java/com/artipie/http/rq/multipart/MultipartHeadersTest.java
+++ b/src/test/java/com/artipie/http/rq/multipart/MultipartHeadersTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.rq.multipart;

--- a/src/test/java/com/artipie/http/rq/multipart/MultipartITCase.java
+++ b/src/test/java/com/artipie/http/rq/multipart/MultipartITCase.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.rq.multipart;

--- a/src/test/java/com/artipie/http/rq/multipart/RqMultipartTest.java
+++ b/src/test/java/com/artipie/http/rq/multipart/RqMultipartTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.rq.multipart;

--- a/src/test/java/com/artipie/http/rq/multipart/StateTest.java
+++ b/src/test/java/com/artipie/http/rq/multipart/StateTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.rq.multipart;

--- a/src/test/java/com/artipie/http/rq/multipart/package-info.java
+++ b/src/test/java/com/artipie/http/rq/multipart/package-info.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 

--- a/src/test/java/com/artipie/http/rq/package-info.java
+++ b/src/test/java/com/artipie/http/rq/package-info.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 

--- a/src/test/java/com/artipie/http/rs/CachedResponseTest.java
+++ b/src/test/java/com/artipie/http/rs/CachedResponseTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.rs;

--- a/src/test/java/com/artipie/http/rs/RsFullTest.java
+++ b/src/test/java/com/artipie/http/rs/RsFullTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.rs;

--- a/src/test/java/com/artipie/http/rs/RsStatusByCodeTest.java
+++ b/src/test/java/com/artipie/http/rs/RsStatusByCodeTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.rs;

--- a/src/test/java/com/artipie/http/rs/RsStatusTest.java
+++ b/src/test/java/com/artipie/http/rs/RsStatusTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.rs;

--- a/src/test/java/com/artipie/http/rs/RsWithBodyTest.java
+++ b/src/test/java/com/artipie/http/rs/RsWithBodyTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.rs;

--- a/src/test/java/com/artipie/http/rs/RsWithHeadersTest.java
+++ b/src/test/java/com/artipie/http/rs/RsWithHeadersTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.rs;

--- a/src/test/java/com/artipie/http/rs/RsWithStatusTest.java
+++ b/src/test/java/com/artipie/http/rs/RsWithStatusTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 

--- a/src/test/java/com/artipie/http/rs/common/RsErrorTest.java
+++ b/src/test/java/com/artipie/http/rs/common/RsErrorTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.rs.common;

--- a/src/test/java/com/artipie/http/rs/common/RsJsonTest.java
+++ b/src/test/java/com/artipie/http/rs/common/RsJsonTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.rs.common;

--- a/src/test/java/com/artipie/http/rs/common/RsTextTest.java
+++ b/src/test/java/com/artipie/http/rs/common/RsTextTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.rs.common;

--- a/src/test/java/com/artipie/http/rs/common/package-info.java
+++ b/src/test/java/com/artipie/http/rs/common/package-info.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 

--- a/src/test/java/com/artipie/http/rs/package-info.java
+++ b/src/test/java/com/artipie/http/rs/package-info.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 

--- a/src/test/java/com/artipie/http/rt/ByMethodsRuleTest.java
+++ b/src/test/java/com/artipie/http/rt/ByMethodsRuleTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.rt;

--- a/src/test/java/com/artipie/http/rt/RtRuleByHeaderTest.java
+++ b/src/test/java/com/artipie/http/rt/RtRuleByHeaderTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.rt;

--- a/src/test/java/com/artipie/http/rt/package-info.java
+++ b/src/test/java/com/artipie/http/rt/package-info.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 

--- a/src/test/java/com/artipie/http/servlet/ServletWrapITCase.java
+++ b/src/test/java/com/artipie/http/servlet/ServletWrapITCase.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.servlet;

--- a/src/test/java/com/artipie/http/servlet/package-info.java
+++ b/src/test/java/com/artipie/http/servlet/package-info.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 

--- a/src/test/java/com/artipie/http/slice/ContentWithSizeTest.java
+++ b/src/test/java/com/artipie/http/slice/ContentWithSizeTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 

--- a/src/test/java/com/artipie/http/slice/GzipSliceTest.java
+++ b/src/test/java/com/artipie/http/slice/GzipSliceTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.slice;

--- a/src/test/java/com/artipie/http/slice/HeadSliceTest.java
+++ b/src/test/java/com/artipie/http/slice/HeadSliceTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.slice;

--- a/src/test/java/com/artipie/http/slice/KeyFromPathTest.java
+++ b/src/test/java/com/artipie/http/slice/KeyFromPathTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.slice;

--- a/src/test/java/com/artipie/http/slice/ListingFormatTest.java
+++ b/src/test/java/com/artipie/http/slice/ListingFormatTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.slice;

--- a/src/test/java/com/artipie/http/slice/LoggingSliceTest.java
+++ b/src/test/java/com/artipie/http/slice/LoggingSliceTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.slice;

--- a/src/test/java/com/artipie/http/slice/SliceDeleteTest.java
+++ b/src/test/java/com/artipie/http/slice/SliceDeleteTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.slice;

--- a/src/test/java/com/artipie/http/slice/SliceDownloadTest.java
+++ b/src/test/java/com/artipie/http/slice/SliceDownloadTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.slice;

--- a/src/test/java/com/artipie/http/slice/SliceITCase.java
+++ b/src/test/java/com/artipie/http/slice/SliceITCase.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.slice;

--- a/src/test/java/com/artipie/http/slice/SliceListingTest.java
+++ b/src/test/java/com/artipie/http/slice/SliceListingTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.slice;

--- a/src/test/java/com/artipie/http/slice/SliceOptionalTest.java
+++ b/src/test/java/com/artipie/http/slice/SliceOptionalTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.slice;

--- a/src/test/java/com/artipie/http/slice/SliceUploadTest.java
+++ b/src/test/java/com/artipie/http/slice/SliceUploadTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.slice;

--- a/src/test/java/com/artipie/http/slice/SliceWithHeadersTest.java
+++ b/src/test/java/com/artipie/http/slice/SliceWithHeadersTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.slice;

--- a/src/test/java/com/artipie/http/slice/TrimPathSliceTest.java
+++ b/src/test/java/com/artipie/http/slice/TrimPathSliceTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.slice;

--- a/src/test/java/com/artipie/http/slice/WithGzipSliceTest.java
+++ b/src/test/java/com/artipie/http/slice/WithGzipSliceTest.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 package com.artipie.http.slice;

--- a/src/test/java/com/artipie/http/slice/package-info.java
+++ b/src/test/java/com/artipie/http/slice/package-info.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
  * https://github.com/artipie/http/blob/master/LICENSE.txt
  */
 


### PR DESCRIPTION
increase license year from 2021 to 2022