### PR TITLE
fix: add realm to WWW-Authenticate header

### DIFF
--- a/src/main/java/com/artipie/http/auth/BasicAuthScheme.java
+++ b/src/main/java/com/artipie/http/auth/BasicAuthScheme.java
@@ -24,6 +24,12 @@ public final class BasicAuthScheme implements AuthScheme {
     public static final String NAME = "Basic";
 
     /**
+     * Basic authentication challenge.
+     */
+    private static final String CHALLENGE =
+        String.format("%s realm=\"artipie\"", BasicAuthScheme.NAME);
+
+    /**
      * Authentication.
      */
     private final Authentication auth;
@@ -87,7 +93,7 @@ public final class BasicAuthScheme implements AuthScheme {
 
         @Override
         public String challenge() {
-            return BasicAuthScheme.NAME;
+            return BasicAuthScheme.CHALLENGE;
         }
     }
 
@@ -105,7 +111,7 @@ public final class BasicAuthScheme implements AuthScheme {
 
         @Override
         public String challenge() {
-            return BasicAuthScheme.NAME;
+            return BasicAuthScheme.CHALLENGE;
         }
     }
 }

--- a/src/test/java/com/artipie/http/auth/BasicAuthSliceTest.java
+++ b/src/test/java/com/artipie/http/auth/BasicAuthSliceTest.java
@@ -55,7 +55,7 @@ final class BasicAuthSliceTest {
             new SliceHasResponse(
                 Matchers.allOf(
                     new RsHasStatus(RsStatus.UNAUTHORIZED),
-                    new RsHasHeaders(new Header("WWW-Authenticate", "Basic"))
+                    new RsHasHeaders(new Header("WWW-Authenticate", "Basic realm=\"artipie\""))
                 ),
                 new RequestLine("POST", "/bar", "HTTP/1.2")
             )


### PR DESCRIPTION
According to RFC7617, the 'realm' parameter is REQUIRED(https://www.rfc-editor.org/rfc/rfc7617.html#section-2)