### PR TITLE
feat: implement `Cleanable` in `CachedYamlPolicy`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>asto-core</artifactId>
-      <version>v1.15.3</version>
+      <version>v1.15.4</version>
     </dependency>
     <dependency>
       <groupId>org.cqfn</groupId>

--- a/src/main/java/com/artipie/http/auth/AuthScheme.java
+++ b/src/main/java/com/artipie/http/auth/AuthScheme.java
@@ -22,8 +22,8 @@ public interface AuthScheme {
     AuthScheme NONE = (hdrs, line)  -> CompletableFuture.completedFuture(
         new AuthScheme.Result() {
             @Override
-            public Optional<Authentication.User> user() {
-                return Optional.of(new Authentication.User("anonymous"));
+            public Optional<AuthUser> user() {
+                return Optional.of(new AuthUser("anonymous"));
             }
 
             @Override
@@ -64,7 +64,7 @@ public interface AuthScheme {
          *
          * @return Authenticated user, empty if not authenticated.
          */
-        Optional<Authentication.User> user();
+        Optional<AuthUser> user();
 
         /**
          * Get authentication challenge that is provided in response WWW-Authenticate header value.
@@ -88,7 +88,7 @@ public interface AuthScheme {
         /**
          * Optional of User.
          */
-        private final Optional<Authentication.User> usr;
+        private final Optional<AuthUser> usr;
 
         /**
          * Challenge.
@@ -100,7 +100,7 @@ public interface AuthScheme {
          * @param usr User
          * @param chllng Challenge
          */
-        public Fake(final Optional<Authentication.User> usr, final String chllng) {
+        public Fake(final Optional<AuthUser> usr, final String chllng) {
             this.usr = usr;
             this.chllng = chllng;
         }
@@ -110,7 +110,7 @@ public interface AuthScheme {
          * @param name User name
          */
         public Fake(final String name) {
-            this(Optional.of(new Authentication.User(name)), Fake.FAKE_CHLLNG);
+            this(Optional.of(new AuthUser(name)), Fake.FAKE_CHLLNG);
         }
 
         /**
@@ -128,7 +128,7 @@ public interface AuthScheme {
             return CompletableFuture.completedFuture(
                 new AuthScheme.Result() {
                     @Override
-                    public Optional<Authentication.User> user() {
+                    public Optional<AuthUser> user() {
                         return Fake.this.usr;
                     }
 

--- a/src/main/java/com/artipie/http/auth/AuthScheme.java
+++ b/src/main/java/com/artipie/http/auth/AuthScheme.java
@@ -23,7 +23,7 @@ public interface AuthScheme {
         new AuthScheme.Result() {
             @Override
             public Optional<AuthUser> user() {
-                return Optional.of(new AuthUser("anonymous", type));
+                return Optional.of(new AuthUser("anonymous", "unknown"));
             }
 
             @Override
@@ -110,7 +110,7 @@ public interface AuthScheme {
          * @param name User name
          */
         public Fake(final String name) {
-            this(Optional.of(new AuthUser(name, type)), Fake.FAKE_CHLLNG);
+            this(Optional.of(new AuthUser(name)), Fake.FAKE_CHLLNG);
         }
 
         /**

--- a/src/main/java/com/artipie/http/auth/AuthScheme.java
+++ b/src/main/java/com/artipie/http/auth/AuthScheme.java
@@ -23,7 +23,7 @@ public interface AuthScheme {
         new AuthScheme.Result() {
             @Override
             public Optional<AuthUser> user() {
-                return Optional.of(new AuthUser("anonymous"));
+                return Optional.of(new AuthUser("anonymous", type));
             }
 
             @Override
@@ -110,7 +110,7 @@ public interface AuthScheme {
          * @param name User name
          */
         public Fake(final String name) {
-            this(Optional.of(new AuthUser(name)), Fake.FAKE_CHLLNG);
+            this(Optional.of(new AuthUser(name, type)), Fake.FAKE_CHLLNG);
         }
 
         /**

--- a/src/main/java/com/artipie/http/auth/AuthUser.java
+++ b/src/main/java/com/artipie/http/auth/AuthUser.java
@@ -10,9 +10,8 @@ import java.util.Objects;
  * Authenticated user.
  *
  * @since 0.16
- * @checkstyle DesignForExtensionCheck (500 lines)
  */
-public class AuthUser {
+public final class AuthUser {
 
     /**
      * User name.
@@ -20,12 +19,28 @@ public class AuthUser {
     private final String uname;
 
     /**
+     * Authentication context.
+     */
+    private final String context;
+
+    /**
      * Ctor.
      *
      * @param name Name of the user
+     * @param context Authentication context
      */
-    public AuthUser(final String name) {
+    public AuthUser(final String name, final String context) {
         this.uname = name;
+        this.context = context;
+    }
+
+    /**
+     * Ctor with test context for usages in tests.
+     *
+     * @param name Name of the user
+     */
+    AuthUser(final String name) {
+        this(name, "test");
     }
 
     /**
@@ -33,12 +48,20 @@ public class AuthUser {
      *
      * @return Name
      */
-    public final String name() {
+    public String name() {
         return this.uname;
     }
 
+    /**
+     * Returns authentication context.
+     * @return Context string
+     */
+    public String authContext() {
+        return this.context;
+    }
+
     @Override
-    public final boolean equals(final Object other) {
+    public boolean equals(final Object other) {
         final boolean res;
         if (this == other) {
             res = true;
@@ -52,7 +75,7 @@ public class AuthUser {
     }
 
     @Override
-    public final int hashCode() {
+    public int hashCode() {
         return Objects.hash(this.uname);
     }
 

--- a/src/main/java/com/artipie/http/auth/AuthUser.java
+++ b/src/main/java/com/artipie/http/auth/AuthUser.java
@@ -1,0 +1,67 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2022 artipie.com
+ * https://github.com/artipie/http/blob/master/LICENSE.txt
+ */
+package com.artipie.http.auth;
+
+import java.util.Objects;
+
+/**
+ * Authenticated user.
+ *
+ * @since 0.16
+ * @checkstyle DesignForExtensionCheck (500 lines)
+ */
+public class AuthUser {
+
+    /**
+     * User name.
+     */
+    private final String uname;
+
+    /**
+     * Ctor.
+     *
+     * @param name Name of the user
+     */
+    public AuthUser(final String name) {
+        this.uname = name;
+    }
+
+    /**
+     * Ger user name.
+     *
+     * @return Name
+     */
+    public final String name() {
+        return this.uname;
+    }
+
+    @Override
+    public final boolean equals(final Object other) {
+        final boolean res;
+        if (this == other) {
+            res = true;
+        } else if (other == null || this.getClass() != other.getClass()) {
+            res = false;
+        } else {
+            final AuthUser user = (AuthUser) other;
+            res = Objects.equals(this.uname, user.uname);
+        }
+        return res;
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(this.uname);
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+            "%s(%s)",
+            this.getClass().getSimpleName(),
+            this.uname
+        );
+    }
+}

--- a/src/main/java/com/artipie/http/auth/Authentication.java
+++ b/src/main/java/com/artipie/http/auth/Authentication.java
@@ -19,12 +19,12 @@ public interface Authentication {
     /**
      * Resolve anyone as an anonymous user.
      */
-    Authentication ANONYMOUS = (name, pswd) -> Optional.of(new AuthUser("anonymous"));
+    Authentication ANONYMOUS = (name, pswd) -> Optional.of(new AuthUser("anonymous", "unknown"));
 
     /**
      * Any user instance.
      */
-    AuthUser ANY_USER = new AuthUser("*");
+    AuthUser ANY_USER = new AuthUser("*", "any");
 
     /**
      * Find user by credentials.
@@ -85,7 +85,7 @@ public interface Authentication {
          * @param password Password.
          */
         public Single(final String user, final String password) {
-            this(new AuthUser(user), password);
+            this(new AuthUser(user, "single"), password);
         }
 
         /**

--- a/src/main/java/com/artipie/http/auth/BasicAuthScheme.java
+++ b/src/main/java/com/artipie/http/auth/BasicAuthScheme.java
@@ -56,7 +56,7 @@ public final class BasicAuthScheme implements AuthScheme {
      * @param headers Headers
      * @return User if authorised
      */
-    private Optional<Authentication.User> user(final Iterable<Map.Entry<String, String>> headers) {
+    private Optional<AuthUser> user(final Iterable<Map.Entry<String, String>> headers) {
         return new RqHeaders(headers, Authorization.NAME).stream()
             .findFirst()
             .map(Authorization::new)
@@ -75,19 +75,19 @@ public final class BasicAuthScheme implements AuthScheme {
         /**
          * Authenticated user.
          */
-        private final Authentication.User usr;
+        private final AuthUser usr;
 
         /**
          * Ctor.
          *
          * @param user Authenticated user.
          */
-        Success(final Authentication.User user) {
+        Success(final AuthUser user) {
             this.usr = user;
         }
 
         @Override
-        public Optional<Authentication.User> user() {
+        public Optional<AuthUser> user() {
             return Optional.of(this.usr);
         }
 
@@ -105,7 +105,7 @@ public final class BasicAuthScheme implements AuthScheme {
     private static class Failure implements Result {
 
         @Override
-        public Optional<Authentication.User> user() {
+        public Optional<AuthUser> user() {
             return Optional.empty();
         }
 

--- a/src/main/java/com/artipie/http/auth/BasicIdentities.java
+++ b/src/main/java/com/artipie/http/auth/BasicIdentities.java
@@ -41,7 +41,7 @@ public final class BasicIdentities implements Identities {
 
     @Override
     @SuppressWarnings("PMD.AvoidDeeplyNestedIfStmts")
-    public Optional<Authentication.User> user(final String line,
+    public Optional<AuthUser> user(final String line,
         final Iterable<Map.Entry<String, String>> headers) {
         return new RqHeaders(headers, Authorization.NAME).stream()
             .findFirst()

--- a/src/main/java/com/artipie/http/auth/BearerAuthScheme.java
+++ b/src/main/java/com/artipie/http/auth/BearerAuthScheme.java
@@ -58,7 +58,7 @@ public final class BearerAuthScheme implements AuthScheme {
      * @param headers Headers
      * @return User, empty if not authenticated
      */
-    private CompletionStage<Optional<Authentication.User>> user(
+    private CompletionStage<Optional<AuthUser>> user(
         final Iterable<Map.Entry<String, String>> headers
     ) {
         return new RqHeaders(headers, Authorization.NAME).stream()
@@ -89,19 +89,19 @@ public final class BearerAuthScheme implements AuthScheme {
         /**
          * Authenticated user.
          */
-        private final Authentication.User usr;
+        private final AuthUser usr;
 
         /**
          * Ctor.
          *
          * @param user Authenticated user.
          */
-        Success(final Authentication.User user) {
+        Success(final AuthUser user) {
             this.usr = user;
         }
 
         @Override
-        public Optional<Authentication.User> user() {
+        public Optional<AuthUser> user() {
             return Optional.of(this.usr);
         }
 
@@ -119,7 +119,7 @@ public final class BearerAuthScheme implements AuthScheme {
     private class Failure implements Result {
 
         @Override
-        public Optional<Authentication.User> user() {
+        public Optional<AuthUser> user() {
             return Optional.empty();
         }
 

--- a/src/main/java/com/artipie/http/auth/Identities.java
+++ b/src/main/java/com/artipie/http/auth/Identities.java
@@ -21,7 +21,7 @@ public interface Identities {
     /**
      * Resolve any request as anonymous user.
      */
-    Identities ANONYMOUS = (line, headers) -> Optional.of(new AuthUser("anonymous"));
+    Identities ANONYMOUS = (line, headers) -> Optional.of(new AuthUser("anonymous", "unknown"));
 
     /**
      * Try to find a user by request head.

--- a/src/main/java/com/artipie/http/auth/Identities.java
+++ b/src/main/java/com/artipie/http/auth/Identities.java
@@ -21,7 +21,7 @@ public interface Identities {
     /**
      * Resolve any request as anonymous user.
      */
-    Identities ANONYMOUS = (line, headers) -> Optional.of(new Authentication.User("anonymous"));
+    Identities ANONYMOUS = (line, headers) -> Optional.of(new AuthUser("anonymous"));
 
     /**
      * Try to find a user by request head.
@@ -29,5 +29,5 @@ public interface Identities {
      * @param headers Request headers
      * @return User name if found
      */
-    Optional<Authentication.User> user(String line, Iterable<Map.Entry<String, String>> headers);
+    Optional<AuthUser> user(String line, Iterable<Map.Entry<String, String>> headers);
 }

--- a/src/main/java/com/artipie/http/auth/JoinedPermissions.java
+++ b/src/main/java/com/artipie/http/auth/JoinedPermissions.java
@@ -39,7 +39,7 @@ public final class JoinedPermissions implements Permissions {
     }
 
     @Override
-    public boolean allowed(final Authentication.User user, final String action) {
+    public boolean allowed(final AuthUser user, final String action) {
         final boolean result;
         if (this.origins.isEmpty()) {
             result = true;

--- a/src/main/java/com/artipie/http/auth/OperationControl.java
+++ b/src/main/java/com/artipie/http/auth/OperationControl.java
@@ -42,7 +42,7 @@ public final class OperationControl {
      * @param user User name
      * @return True if authorized
      */
-    public boolean allowed(final Authentication.User user) {
-        return this.policy.getPermissions(user.name()).implies(this.perm);
+    public boolean allowed(final AuthUser user) {
+        return this.policy.getPermissions(user).implies(this.perm);
     }
 }

--- a/src/main/java/com/artipie/http/auth/Permission.java
+++ b/src/main/java/com/artipie/http/auth/Permission.java
@@ -18,7 +18,7 @@ public interface Permission {
      * @param user User name
      * @return True if authorized
      */
-    boolean allowed(Authentication.User user);
+    boolean allowed(AuthUser user);
 
     /**
      * Permission by name.
@@ -56,7 +56,7 @@ public interface Permission {
         }
 
         @Override
-        public boolean allowed(final Authentication.User user) {
+        public boolean allowed(final AuthUser user) {
             boolean res = false;
             for (final String synonym : this.action.names()) {
                 if (this.perm.allowed(user, synonym)) {
@@ -100,7 +100,7 @@ public interface Permission {
         }
 
         @Override
-        public boolean allowed(final Authentication.User user) {
+        public boolean allowed(final AuthUser user) {
             return StreamSupport.stream(this.origin.spliterator(), false).allMatch(
                 perm -> perm.allowed(user)
             );
@@ -140,7 +140,7 @@ public interface Permission {
         }
 
         @Override
-        public boolean allowed(final Authentication.User user) {
+        public boolean allowed(final AuthUser user) {
             return StreamSupport.stream(this.origin.spliterator(), false).anyMatch(
                 perm -> perm.allowed(user)
             );

--- a/src/main/java/com/artipie/http/auth/Permissions.java
+++ b/src/main/java/com/artipie/http/auth/Permissions.java
@@ -22,7 +22,7 @@ public interface Permissions {
      * @param action Action to perform
      * @return True if allowed
      */
-    boolean allowed(Authentication.User user, String action);
+    boolean allowed(AuthUser user, String action);
 
     /**
      * Abstract decorator for Permissions.
@@ -46,7 +46,7 @@ public interface Permissions {
         }
 
         @Override
-        public final boolean allowed(final Authentication.User user, final String action) {
+        public final boolean allowed(final AuthUser user, final String action) {
             return this.origin.allowed(user, action);
         }
     }
@@ -80,7 +80,7 @@ public interface Permissions {
         }
 
         @Override
-        public boolean allowed(final Authentication.User user, final String act) {
+        public boolean allowed(final AuthUser user, final String act) {
             return this.username.equals(user.name()) && this.action.equals(act);
         }
     }

--- a/src/main/java/com/artipie/http/auth/TokenAuthentication.java
+++ b/src/main/java/com/artipie/http/auth/TokenAuthentication.java
@@ -20,5 +20,5 @@ public interface TokenAuthentication {
      * @param token Token.
      * @return User if authenticated.
      */
-    CompletionStage<Optional<Authentication.User>> user(String token);
+    CompletionStage<Optional<AuthUser>> user(String token);
 }

--- a/src/main/java/com/artipie/http/auth/Tokens.java
+++ b/src/main/java/com/artipie/http/auth/Tokens.java
@@ -21,5 +21,5 @@ public interface Tokens {
      * @param user User to issue token for
      * @return String token
      */
-    String generate(Authentication.User user);
+    String generate(AuthUser user);
 }

--- a/src/main/java/com/artipie/security/policy/CachedYamlPolicy.java
+++ b/src/main/java/com/artipie/security/policy/CachedYamlPolicy.java
@@ -14,6 +14,7 @@ import com.artipie.asto.blocking.BlockingStorage;
 import com.artipie.asto.misc.Cleanable;
 import com.artipie.asto.misc.UncheckedFunc;
 import com.artipie.asto.misc.UncheckedSupplier;
+import com.artipie.http.auth.AuthUser;
 import com.artipie.security.perms.EmptyPermissions;
 import com.artipie.security.perms.PermissionConfig;
 import com.artipie.security.perms.PermissionsLoader;
@@ -156,9 +157,9 @@ public final class CachedYamlPolicy implements Policy<UserPermissions>, Cleanabl
     }
 
     @Override
-    public UserPermissions getPermissions(final String uname) {
+    public UserPermissions getPermissions(final AuthUser user) {
         try {
-            return this.cache.get(uname, this.createUserPermissions(uname));
+            return this.cache.get(user.name(), this.createUserPermissions(user.name()));
         } catch (final ExecutionException err) {
             Logger.error(this, err.getMessage());
             throw new ArtipieException(err);

--- a/src/main/java/com/artipie/security/policy/Policy.java
+++ b/src/main/java/com/artipie/security/policy/Policy.java
@@ -4,6 +4,7 @@
  */
 package com.artipie.security.policy;
 
+import com.artipie.http.auth.AuthUser;
 import com.artipie.security.perms.AdapterBasicPermission;
 import com.artipie.security.perms.FreePermissions;
 import java.security.PermissionCollection;
@@ -11,15 +12,15 @@ import java.security.PermissionCollection;
 /**
  * Security policy.
  *
- * @param <C> Implementation of {@link PermissionCollection}
+ * @param <P> Implementation of {@link PermissionCollection}
  * @since 1.2
  */
-public interface Policy<C extends PermissionCollection> {
+public interface Policy<P extends PermissionCollection> {
 
     /**
      * Free policy for any user returns {@link FreePermissions} which implies any permission.
      */
-    Policy<PermissionCollection> FREE = uname -> new FreePermissions();
+    Policy<PermissionCollection> FREE = user -> new FreePermissions();
 
     /**
      * Get collection of permissions {@link PermissionCollection} for user by username.
@@ -28,9 +29,9 @@ public interface Policy<C extends PermissionCollection> {
      * list of {@link AdapterBasicPermission} for adapter with basic permissions and
      * another permissions' implementation for docker adapter.
      *
-     * @param uname User name
+     * @param user User
      * @return Set of {@link PermissionCollection}
      */
-    C getPermissions(String uname);
+    P getPermissions(AuthUser user);
 
 }

--- a/src/main/java/com/artipie/security/policy/PolicyByUsername.java
+++ b/src/main/java/com/artipie/security/policy/PolicyByUsername.java
@@ -4,6 +4,7 @@
  */
 package com.artipie.security.policy;
 
+import com.artipie.http.auth.AuthUser;
 import com.artipie.security.perms.EmptyPermissions;
 import com.artipie.security.perms.FreePermissions;
 import java.security.PermissionCollection;
@@ -29,9 +30,9 @@ public final class PolicyByUsername implements Policy<PermissionCollection> {
     }
 
     @Override
-    public PermissionCollection getPermissions(final String uname) {
+    public PermissionCollection getPermissions(final AuthUser user) {
         final PermissionCollection res;
-        if (this.name.equals(uname)) {
+        if (this.name.equals(user.name())) {
             res = new FreePermissions();
         } else {
             res = EmptyPermissions.INSTANCE;

--- a/src/main/java/com/artipie/security/policy/YamlPolicyFactory.java
+++ b/src/main/java/com/artipie/security/policy/YamlPolicyFactory.java
@@ -17,7 +17,7 @@ import java.io.UncheckedIOException;
  * Configuration format is the following:
  *
  * policy:
- *   type: yaml_policy
+ *   type: artipie_policy
  *   eviction_millis: 60000 # not required, default 3 min
  *   storage:
  *     type: fs
@@ -37,7 +37,7 @@ import java.io.UncheckedIOException;
  *
  * @since 1.2
  */
-@ArtipiePolicyFactory("yaml_policy")
+@ArtipiePolicyFactory("artipie_policy")
 public final class YamlPolicyFactory implements PolicyFactory {
 
     @Override

--- a/src/test/java/com/artipie/http/auth/AuthSchemeNoneTest.java
+++ b/src/test/java/com/artipie/http/auth/AuthSchemeNoneTest.java
@@ -23,7 +23,7 @@ final class AuthSchemeNoneTest {
             AuthScheme.NONE.authenticate(Headers.EMPTY, "any")
                 .toCompletableFuture().join()
                 .user()
-                .map(Authentication.User::name),
+                .map(AuthUser::name),
             new IsEqual<>(Optional.of("anonymous"))
         );
     }

--- a/src/test/java/com/artipie/http/auth/BasicAuthSliceTest.java
+++ b/src/test/java/com/artipie/http/auth/BasicAuthSliceTest.java
@@ -68,7 +68,7 @@ final class BasicAuthSliceTest {
         MatcherAssert.assertThat(
             new BasicAuthSlice(
                 new SliceSimple(new RsWithStatus(RsStatus.OK)),
-                (user, pswd) -> Optional.of(new Authentication.User(name)),
+                (user, pswd) -> Optional.of(new AuthUser(name)),
                 user -> false
             ),
             new SliceHasResponse(

--- a/src/test/java/com/artipie/http/auth/BasicAuthzSliceTest.java
+++ b/src/test/java/com/artipie/http/auth/BasicAuthzSliceTest.java
@@ -78,7 +78,7 @@ class BasicAuthzSliceTest {
         MatcherAssert.assertThat(
             new BasicAuthzSlice(
                 new SliceSimple(new RsWithStatus(RsStatus.OK)),
-                (user, pswd) -> Optional.of(new Authentication.User(name)),
+                (user, pswd) -> Optional.of(new AuthUser(name)),
                 new OperationControl(
                     user -> EmptyPermissions.INSTANCE,
                     new AdapterBasicPermission("any", Action.NONE)

--- a/src/test/java/com/artipie/http/auth/BasicIdentitiesTest.java
+++ b/src/test/java/com/artipie/http/auth/BasicIdentitiesTest.java
@@ -25,7 +25,7 @@ public final class BasicIdentitiesTest {
      * Stub for interface.
      */
     private final Authentication auth =
-        (username, password) -> Optional.of(new Authentication.User(username));
+        (username, password) -> Optional.of(new AuthUser(username));
 
     @Test
     void userWithEmptyHeaders() {
@@ -50,7 +50,7 @@ public final class BasicIdentitiesTest {
         );
         MatcherAssert.assertThat(
             new BasicIdentities(this.auth).user("", headers),
-            new IsEqual<>(Optional.of(new Authentication.User("Aladdin")))
+            new IsEqual<>(Optional.of(new AuthUser("Aladdin")))
         );
     }
 }

--- a/src/test/java/com/artipie/http/auth/BearerAuthSchemeTest.java
+++ b/src/test/java/com/artipie/http/auth/BearerAuthSchemeTest.java
@@ -35,7 +35,7 @@ final class BearerAuthSchemeTest {
             tkn -> {
                 capture.set(tkn);
                 return CompletableFuture.completedFuture(
-                    Optional.of(new Authentication.User("alice"))
+                    Optional.of(new AuthUser("alice"))
                 );
             },
             "realm=\"artipie.com\""
@@ -53,9 +53,9 @@ final class BearerAuthSchemeTest {
     @ValueSource(strings = {"bob"})
     @NullSource
     void shouldReturnUserInResult(final String name) {
-        final Optional<Authentication.User> user = Optional.ofNullable(name)
-            .map(Authentication.User::new);
-        final Optional<Authentication.User> result = new BearerAuthScheme(
+        final Optional<AuthUser> user = Optional.ofNullable(name)
+            .map(AuthUser::new);
+        final Optional<AuthUser> result = new BearerAuthScheme(
             tkn -> CompletableFuture.completedFuture(user),
             "whatever"
         ).authenticate(

--- a/src/test/java/com/artipie/http/auth/JoinedPermissionsTest.java
+++ b/src/test/java/com/artipie/http/auth/JoinedPermissionsTest.java
@@ -32,7 +32,7 @@ final class JoinedPermissionsTest {
         MatcherAssert.assertThat(
             new JoinedPermissions(
                 Streams.concat(fake(one), fake(two)).collect(Collectors.toList())
-            ).allowed(new Authentication.User("some name"), "some action"),
+            ).allowed(new AuthUser("some name"), "some action"),
             new IsEqual<>(allow)
         );
     }

--- a/src/test/java/com/artipie/http/auth/PermissionAllTest.java
+++ b/src/test/java/com/artipie/http/auth/PermissionAllTest.java
@@ -38,7 +38,7 @@ class PermissionAllTest {
                 ).map(
                     str -> (Permission) user -> Boolean.parseBoolean(str)
                 ).collect(Collectors.toList())
-            ).allowed(new Authentication.User("alice")),
+            ).allowed(new AuthUser("alice")),
             new IsEqual<>(expected)
         );
     }

--- a/src/test/java/com/artipie/http/auth/PermissionAnyTest.java
+++ b/src/test/java/com/artipie/http/auth/PermissionAnyTest.java
@@ -38,7 +38,7 @@ class PermissionAnyTest {
                 ).map(
                     str -> (Permission) user -> Boolean.parseBoolean(str)
                 ).collect(Collectors.toList())
-            ).allowed(new Authentication.User("aladdin")),
+            ).allowed(new AuthUser("aladdin")),
             new IsEqual<>(expected)
         );
     }

--- a/src/test/java/com/artipie/http/auth/PermissionByNameTest.java
+++ b/src/test/java/com/artipie/http/auth/PermissionByNameTest.java
@@ -36,7 +36,7 @@ class PermissionByNameTest {
             new Permission.ByName(
                 (identity, act) -> name.equals(identity.name()) && act.equals(perm),
                 action
-            ).allowed(new Authentication.User(name)),
+            ).allowed(new AuthUser(name)),
             new IsEqual<>(true)
         );
     }
@@ -48,7 +48,7 @@ class PermissionByNameTest {
             new Permission.ByName(
                 (identity, act) -> user.equals(identity.name()) && act.equals("a"),
                 () -> Arrays.asList("b", "c")
-            ).allowed(new Authentication.User(user)),
+            ).allowed(new AuthUser(user)),
             new IsEqual<>(false)
         );
     }

--- a/src/test/java/com/artipie/http/auth/PermissionsTest.java
+++ b/src/test/java/com/artipie/http/auth/PermissionsTest.java
@@ -29,7 +29,7 @@ public final class PermissionsTest {
                     MatcherAssert.assertThat(
                         "Username is forwarded to delegate without modification",
                         identity,
-                        new IsEqual<>(new Authentication.User(name))
+                        new IsEqual<>(new AuthUser(name))
                     );
                     MatcherAssert.assertThat(
                         "Action is forwarded to delegate without modification",
@@ -38,7 +38,7 @@ public final class PermissionsTest {
                     );
                     return result;
                 }
-            ).allowed(new Authentication.User(name), act),
+            ).allowed(new AuthUser(name), act),
             new IsEqual<>(result)
         );
     }
@@ -56,7 +56,7 @@ public final class PermissionsTest {
     ) {
         MatcherAssert.assertThat(
             new Permissions.Single("Aladdin", "read")
-                .allowed(new Authentication.User(username), action),
+                .allowed(new AuthUser(username), action),
             new IsEqual<>(allow)
         );
     }

--- a/src/test/java/com/artipie/security/policy/CachedYamlPolicyTest.java
+++ b/src/test/java/com/artipie/security/policy/CachedYamlPolicyTest.java
@@ -65,7 +65,7 @@ class CachedYamlPolicyTest {
         );
         MatcherAssert.assertThat(
             "Alice can read from maven repo",
-            policy.getPermissions(new AuthUser("alice"))
+            policy.getPermissions(new AuthUser("alice", "test"))
                 .implies(new AdapterBasicPermission("maven-repo", Action.Standard.READ)),
             new IsEqual<>(true)
         );
@@ -87,7 +87,7 @@ class CachedYamlPolicyTest {
         this.user.invalidateAll();
         MatcherAssert.assertThat(
             "Alice can read from maven repo",
-            policy.getPermissions(new AuthUser("alice"))
+            policy.getPermissions(new AuthUser("alice", "test"))
                 .implies(new AdapterBasicPermission("maven-repo", Action.Standard.READ)),
             new IsEqual<>(true)
         );
@@ -116,7 +116,7 @@ class CachedYamlPolicyTest {
         );
         MatcherAssert.assertThat(
             "Alice can read from rpm repo",
-            policy.getPermissions(new AuthUser("alice"))
+            policy.getPermissions(new AuthUser("alice", "test"))
                 .implies(new AdapterBasicPermission("rpm-repo", Action.Standard.READ)),
             new IsEqual<>(true)
         );
@@ -146,7 +146,7 @@ class CachedYamlPolicyTest {
         );
         MatcherAssert.assertThat(
             "Alice can read from maven repo",
-            policy.getPermissions(new AuthUser("alice"))
+            policy.getPermissions(new AuthUser("alice", "test"))
                 .implies(new AdapterBasicPermission("maven-repo", Action.Standard.READ)),
             new IsEqual<>(true)
         );
@@ -167,7 +167,7 @@ class CachedYamlPolicyTest {
         );
         MatcherAssert.assertThat(
             "Alice can read from rpm repo",
-            policy.getPermissions(new AuthUser("alice"))
+            policy.getPermissions(new AuthUser("alice", "test"))
                 .implies(new AdapterBasicPermission("rpm-repo", Action.Standard.READ)),
             new IsEqual<>(true)
         );
@@ -198,7 +198,7 @@ class CachedYamlPolicyTest {
         );
         MatcherAssert.assertThat(
             "John cannot write into test-repo",
-            policy.getPermissions(new AuthUser("john")).implies(
+            policy.getPermissions(new AuthUser("john", "test")).implies(
                 new AdapterBasicPermission("test-repo", Action.Standard.WRITE)
             ),
             new IsEqual<>(false)
@@ -230,7 +230,7 @@ class CachedYamlPolicyTest {
         );
         MatcherAssert.assertThat(
             "John cannot write into test-repo",
-            policy.getPermissions(new AuthUser("john")).implies(
+            policy.getPermissions(new AuthUser("john", "test")).implies(
                 new AdapterBasicPermission("test-repo", Action.Standard.WRITE)
             ),
             new IsEqual<>(false)
@@ -261,7 +261,7 @@ class CachedYamlPolicyTest {
         );
         MatcherAssert.assertThat(
             "Alice can read from maven repo",
-            policy.getPermissions(new AuthUser("alice"))
+            policy.getPermissions(new AuthUser("alice", "test"))
                 .implies(new AdapterBasicPermission("maven-repo", Action.Standard.READ)),
             new IsEqual<>(true)
         );

--- a/src/test/java/com/artipie/security/policy/CachedYamlPolicyTest.java
+++ b/src/test/java/com/artipie/security/policy/CachedYamlPolicyTest.java
@@ -7,6 +7,7 @@ package com.artipie.security.policy;
 import com.artipie.asto.Key;
 import com.artipie.asto.blocking.BlockingStorage;
 import com.artipie.asto.memory.InMemoryStorage;
+import com.artipie.http.auth.AuthUser;
 import com.artipie.security.perms.Action;
 import com.artipie.security.perms.AdapterBasicPermission;
 import com.artipie.security.perms.User;
@@ -64,7 +65,7 @@ class CachedYamlPolicyTest {
         );
         MatcherAssert.assertThat(
             "Alice can read from maven repo",
-            policy.getPermissions("alice")
+            policy.getPermissions(new AuthUser("alice"))
                 .implies(new AdapterBasicPermission("maven-repo", Action.Standard.READ)),
             new IsEqual<>(true)
         );
@@ -86,7 +87,7 @@ class CachedYamlPolicyTest {
         this.user.invalidateAll();
         MatcherAssert.assertThat(
             "Alice can read from maven repo",
-            policy.getPermissions("alice")
+            policy.getPermissions(new AuthUser("alice"))
                 .implies(new AdapterBasicPermission("maven-repo", Action.Standard.READ)),
             new IsEqual<>(true)
         );
@@ -115,7 +116,7 @@ class CachedYamlPolicyTest {
         );
         MatcherAssert.assertThat(
             "Alice can read from rpm repo",
-            policy.getPermissions("alice")
+            policy.getPermissions(new AuthUser("alice"))
                 .implies(new AdapterBasicPermission("rpm-repo", Action.Standard.READ)),
             new IsEqual<>(true)
         );
@@ -145,7 +146,7 @@ class CachedYamlPolicyTest {
         );
         MatcherAssert.assertThat(
             "Alice can read from maven repo",
-            policy.getPermissions("alice")
+            policy.getPermissions(new AuthUser("alice"))
                 .implies(new AdapterBasicPermission("maven-repo", Action.Standard.READ)),
             new IsEqual<>(true)
         );
@@ -166,7 +167,7 @@ class CachedYamlPolicyTest {
         );
         MatcherAssert.assertThat(
             "Alice can read from rpm repo",
-            policy.getPermissions("alice")
+            policy.getPermissions(new AuthUser("alice"))
                 .implies(new AdapterBasicPermission("rpm-repo", Action.Standard.READ)),
             new IsEqual<>(true)
         );
@@ -197,7 +198,7 @@ class CachedYamlPolicyTest {
         );
         MatcherAssert.assertThat(
             "John cannot write into test-repo",
-            policy.getPermissions("john").implies(
+            policy.getPermissions(new AuthUser("john")).implies(
                 new AdapterBasicPermission("test-repo", Action.Standard.WRITE)
             ),
             new IsEqual<>(false)
@@ -229,7 +230,7 @@ class CachedYamlPolicyTest {
         );
         MatcherAssert.assertThat(
             "John cannot write into test-repo",
-            policy.getPermissions("john").implies(
+            policy.getPermissions(new AuthUser("john")).implies(
                 new AdapterBasicPermission("test-repo", Action.Standard.WRITE)
             ),
             new IsEqual<>(false)
@@ -260,7 +261,7 @@ class CachedYamlPolicyTest {
         );
         MatcherAssert.assertThat(
             "Alice can read from maven repo",
-            policy.getPermissions("alice")
+            policy.getPermissions(new AuthUser("alice"))
                 .implies(new AdapterBasicPermission("maven-repo", Action.Standard.READ)),
             new IsEqual<>(true)
         );

--- a/src/test/java/com/artipie/security/policy/CachedYamlPolicyTest.java
+++ b/src/test/java/com/artipie/security/policy/CachedYamlPolicyTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
  * Test for {@link CachedYamlPolicy} and {@link UserPermissions}.
  * @since 1.2
  */
-@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+@SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.TooManyMethods"})
 class CachedYamlPolicyTest {
 
     /**
@@ -216,6 +216,69 @@ class CachedYamlPolicyTest {
             "Cache with role permissions has 2 items",
             this.roles.size(),
             new IsEqual<>(2L)
+        );
+    }
+
+    @Test
+    void invalidatesGroupCaches() {
+        this.asto.save(new Key.From("users/john.yml"), this.johnConfig());
+        this.asto.save(new Key.From("roles/java-dev.yaml"), this.javaDev());
+        this.asto.save(new Key.From("roles/tester.yaml"), this.tester());
+        final CachedYamlPolicy policy = new CachedYamlPolicy(
+            this.cache, this.user, this.roles, this.asto
+        );
+        MatcherAssert.assertThat(
+            "John cannot write into test-repo",
+            policy.getPermissions("john").implies(
+                new AdapterBasicPermission("test-repo", Action.Standard.WRITE)
+            ),
+            new IsEqual<>(false)
+        );
+        policy.invalidate("tester");
+        MatcherAssert.assertThat(
+            "Cache with UserPermissions has 1 item",
+            this.cache.size(),
+            new IsEqual<>(1L)
+        );
+        MatcherAssert.assertThat(
+            "Cache with user individual permissions and roles has 1 item",
+            this.user.size(),
+            new IsEqual<>(1L)
+        );
+        MatcherAssert.assertThat(
+            "Cache with role permissions has 'java-dev' group",
+            this.roles.size() == 1L && this.roles.asMap().containsKey("java-dev")
+        );
+    }
+
+    @Test
+    void invalidatesUsersCache() {
+        this.asto.save(new Key.From("users/alice.yml"), this.aliceConfig());
+        this.asto.save(new Key.From("roles/java-dev.yaml"), this.javaDev());
+        final CachedYamlPolicy policy = new CachedYamlPolicy(
+            this.cache, this.user, this.roles, this.asto
+        );
+        MatcherAssert.assertThat(
+            "Alice can read from maven repo",
+            policy.getPermissions("alice")
+                .implies(new AdapterBasicPermission("maven-repo", Action.Standard.READ)),
+            new IsEqual<>(true)
+        );
+        policy.invalidate("alice");
+        MatcherAssert.assertThat(
+            "Cache with UserPermissions has 1 item",
+            this.cache.size(),
+            new IsEqual<>(0L)
+        );
+        MatcherAssert.assertThat(
+            "Cache with user individual permissions and roles has 1 item",
+            this.user.size(),
+            new IsEqual<>(0L)
+        );
+        MatcherAssert.assertThat(
+            "Cache with role permissions has 1 item",
+            this.roles.size(),
+            new IsEqual<>(1L)
         );
     }
 

--- a/src/test/java/com/artipie/security/policy/PoliciesLoaderTest.java
+++ b/src/test/java/com/artipie/security/policy/PoliciesLoaderTest.java
@@ -6,6 +6,7 @@ package com.artipie.security.policy;
 
 import com.amihaiemil.eoyaml.Yaml;
 import com.artipie.ArtipieException;
+import com.artipie.http.auth.AuthUser;
 import java.security.Permissions;
 import java.util.Collections;
 import org.hamcrest.MatcherAssert;
@@ -24,9 +25,9 @@ public class PoliciesLoaderTest {
     void createsYamlPolicy() {
         MatcherAssert.assertThat(
             new PoliciesLoader().newObject(
-                "yaml_policy",
+                "artipie_policy",
                 new YamlPolicyConfig(
-                    Yaml.createYamlMappingBuilder().add("type", "yaml_policy")
+                    Yaml.createYamlMappingBuilder().add("type", "artipie_policy")
                         .add(
                             "storage",
                             Yaml.createYamlMappingBuilder().add("type", "fs")
@@ -93,7 +94,7 @@ public class PoliciesLoaderTest {
     public static final class TestPolicy implements Policy<Permissions> {
 
         @Override
-        public Permissions getPermissions(final String uname) {
+        public Permissions getPermissions(final AuthUser uname) {
             return new Permissions();
         }
     }

--- a/src/test/java/com/artipie/security/policy/YamlPolicyFactoryTest.java
+++ b/src/test/java/com/artipie/security/policy/YamlPolicyFactoryTest.java
@@ -21,7 +21,7 @@ class YamlPolicyFactoryTest {
         MatcherAssert.assertThat(
             new YamlPolicyFactory().getPolicy(
                 new YamlPolicyConfig(
-                    Yaml.createYamlMappingBuilder().add("type", "yaml_policy")
+                    Yaml.createYamlMappingBuilder().add("type", "artipie_policy")
                         .add(
                             "storage",
                             Yaml.createYamlMappingBuilder().add("type", "fs")
@@ -38,7 +38,7 @@ class YamlPolicyFactoryTest {
         MatcherAssert.assertThat(
             new YamlPolicyFactory().getPolicy(
                 new YamlPolicyConfig(
-                    Yaml.createYamlMappingBuilder().add("type", "yaml_policy")
+                    Yaml.createYamlMappingBuilder().add("type", "artipie_policy")
                         .add("eviction_millis", "50000")
                         .add(
                             "storage",


### PR DESCRIPTION
part of #501 
Corrected `CachedYamlPolicy` to implement `Cleanable` interface from `asto` to invalidate caches values.
Also, as we discussed, extracted `AuthUser` class from `Authentication` interface, removed groups as we do not need them anymore and used the class as method parameter in `Policy`.