### PR TITLE
fix: skip Accept header parsing in case no Accept headers presented

### DIFF
--- a/src/main/java/com/artipie/http/headers/Accept.java
+++ b/src/main/java/com/artipie/http/headers/Accept.java
@@ -5,6 +5,7 @@
 package com.artipie.http.headers;
 
 import com.artipie.http.rq.RqHeaders;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -14,6 +15,7 @@ import wtf.g4s8.mime.MimeType;
  * Accept header, check
  * <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept">documentation</a>
  * for more details.
+ *
  * @since 0.19
  */
 public final class Accept {
@@ -40,10 +42,16 @@ public final class Accept {
      * Parses `Accept` header values, sorts them according to weight and returns in
      * corresponding order.
      * @return Set or the values
+     * @checkstyle ReturnCountCheck (11 lines)
      */
+    @SuppressWarnings("PMD.OnlyOneReturn")
     public List<String> values() {
+        final RqHeaders rqh = new RqHeaders(this.headers, Accept.NAME);
+        if (rqh.size() == 0) {
+            return Collections.emptyList();
+        }
         return MimeType.parse(
-            new RqHeaders(this.headers, Accept.NAME).stream().collect(Collectors.joining(","))
+            rqh.stream().collect(Collectors.joining(","))
         ).stream()
             .map(mime -> String.format("%s/%s", mime.type(), mime.subtype()))
             .collect(Collectors.toList());

--- a/src/test/java/com/artipie/http/headers/AcceptTest.java
+++ b/src/test/java/com/artipie/http/headers/AcceptTest.java
@@ -77,4 +77,14 @@ class AcceptTest {
             )
         );
     }
+
+    @Test
+    void returnEmptyValuesIfNoAcceptHeader() {
+        MatcherAssert.assertThat(
+            new Accept(
+                Headers.EMPTY
+            ).values(),
+            Matchers.hasSize(0)
+        );
+    }
 }


### PR DESCRIPTION
closes #520 