### PR TITLE
feat: factory should return collection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>asto-core</artifactId>
-      <version>v1.15.4</version>
+      <version>v1.15.5</version>
     </dependency>
     <dependency>
       <groupId>org.cqfn</groupId>

--- a/src/main/java/com/artipie/security/perms/AdapterAllPermissionFactory.java
+++ b/src/main/java/com/artipie/security/perms/AdapterAllPermissionFactory.java
@@ -5,20 +5,18 @@
 package com.artipie.security.perms;
 
 import java.security.AllPermission;
-import java.security.Permission;
-import java.util.Collection;
-import java.util.Collections;
+import java.security.PermissionCollection;
 
 /**
  * Permission factory for {@link AllPermission}.
  * @since 1.2
  */
 @ArtipiePermissionFactory("adapter_all_permission")
-public final class AdapterAllPermissionFactory implements PermissionFactory {
+public final class AdapterAllPermissionFactory implements PermissionFactory<PermissionCollection> {
 
     @Override
-    public Collection<Permission> newPermission(final PermissionConfig<?> config) {
-        return Collections.singleton(new AllPermission());
+    public PermissionCollection newPermissions(final PermissionConfig config) {
+        return new AllPermission().newPermissionCollection();
     }
 
 }

--- a/src/main/java/com/artipie/security/perms/AdapterAllPermissionFactory.java
+++ b/src/main/java/com/artipie/security/perms/AdapterAllPermissionFactory.java
@@ -6,6 +6,8 @@ package com.artipie.security.perms;
 
 import java.security.AllPermission;
 import java.security.Permission;
+import java.util.Collection;
+import java.util.Collections;
 
 /**
  * Permission factory for {@link AllPermission}.
@@ -15,8 +17,8 @@ import java.security.Permission;
 public final class AdapterAllPermissionFactory implements PermissionFactory {
 
     @Override
-    public Permission newPermission(final PermissionConfig config) {
-        return new AllPermission();
+    public Collection<Permission> newPermission(final PermissionConfig<?> config) {
+        return Collections.singleton(new AllPermission());
     }
 
 }

--- a/src/main/java/com/artipie/security/perms/AdapterBasicPermission.java
+++ b/src/main/java/com/artipie/security/perms/AdapterBasicPermission.java
@@ -90,7 +90,7 @@ public final class AdapterBasicPermission extends Permission {
      *
      * @param config Permission configuration
      */
-    public AdapterBasicPermission(final PermissionConfig config) {
+    public AdapterBasicPermission(final PermissionConfig<?> config) {
         this(config.name(), config.sequence(config.name()));
     }
 

--- a/src/main/java/com/artipie/security/perms/AdapterBasicPermission.java
+++ b/src/main/java/com/artipie/security/perms/AdapterBasicPermission.java
@@ -6,10 +6,10 @@ package com.artipie.security.perms;
 
 import java.security.Permission;
 import java.security.PermissionCollection;
+import java.util.Collection;
 import java.util.Enumeration;
 import java.util.Locale;
 import java.util.Objects;
-import java.util.Set;
 import java.util.StringJoiner;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
@@ -81,17 +81,8 @@ public final class AdapterBasicPermission extends Permission {
      * @param repo Repository name
      * @param strings Actions set
      */
-    public AdapterBasicPermission(final String repo, final Set<String> strings) {
+    public AdapterBasicPermission(final String repo, final Collection<String> strings) {
         this(repo, AdapterBasicPermission.maskFromActions(strings));
-    }
-
-    /**
-     * Constructs a permission from configuration.
-     *
-     * @param config Permission configuration
-     */
-    public AdapterBasicPermission(final PermissionConfig<?> config) {
-        this(config.name(), config.sequence(config.name()));
     }
 
     @Override
@@ -169,7 +160,7 @@ public final class AdapterBasicPermission extends Permission {
      * @param actions The set of actions
      * @return Integer mask
      */
-    private static int maskFromActions(final Set<String> actions) {
+    private static int maskFromActions(final Collection<String> actions) {
         int res = Action.NONE.mask();
         if (actions.isEmpty() || actions.size() == 1 && actions.contains("")) {
             res = Action.NONE.mask();

--- a/src/main/java/com/artipie/security/perms/AdapterBasicPermissionFactory.java
+++ b/src/main/java/com/artipie/security/perms/AdapterBasicPermissionFactory.java
@@ -4,20 +4,24 @@
  */
 package com.artipie.security.perms;
 
-import java.security.Permission;
-import java.util.Collection;
-import java.util.Collections;
-
 /**
  * Factory for {@link AdapterBasicPermission}.
  * @since 1.2
  */
 @ArtipiePermissionFactory("adapter_basic_permission")
-public final class AdapterBasicPermissionFactory implements PermissionFactory {
+public final class AdapterBasicPermissionFactory implements
+    PermissionFactory<AdapterBasicPermission.AdapterBasicPermissionCollection> {
 
     @Override
-    public Collection<Permission> newPermission(final PermissionConfig<?> config) {
-        return Collections.singleton(new AdapterBasicPermission(config));
+    public AdapterBasicPermission.AdapterBasicPermissionCollection newPermissions(
+        final PermissionConfig config
+    ) {
+        final AdapterBasicPermission.AdapterBasicPermissionCollection res =
+            new AdapterBasicPermission.AdapterBasicPermissionCollection();
+        for (final String name : config.keys()) {
+            res.add(new AdapterBasicPermission(name, config.sequence(name)));
+        }
+        return res;
     }
 
 }

--- a/src/main/java/com/artipie/security/perms/AdapterBasicPermissionFactory.java
+++ b/src/main/java/com/artipie/security/perms/AdapterBasicPermissionFactory.java
@@ -5,6 +5,8 @@
 package com.artipie.security.perms;
 
 import java.security.Permission;
+import java.util.Collection;
+import java.util.Collections;
 
 /**
  * Factory for {@link AdapterBasicPermission}.
@@ -14,8 +16,8 @@ import java.security.Permission;
 public final class AdapterBasicPermissionFactory implements PermissionFactory {
 
     @Override
-    public Permission newPermission(final PermissionConfig config) {
-        return new AdapterBasicPermission(config);
+    public Collection<Permission> newPermission(final PermissionConfig<?> config) {
+        return Collections.singleton(new AdapterBasicPermission(config));
     }
 
 }

--- a/src/main/java/com/artipie/security/perms/PermissionConfig.java
+++ b/src/main/java/com/artipie/security/perms/PermissionConfig.java
@@ -11,9 +11,10 @@ import java.util.stream.Collectors;
 
 /**
  * Permission configuration.
+ * @param <T> Configuration original format type: yaml, json, database table, string etc.
  * @since 1.2
  */
-public interface PermissionConfig {
+public interface PermissionConfig<T> {
 
     /**
      * Permission name. The name can vary from the permission model,
@@ -39,13 +40,20 @@ public interface PermissionConfig {
     Set<String> sequence(String key);
 
     /**
+     * Get config in its original form: it can be yaml, json, string or
+     * any other representation from what config is parsed.
+     * @return Original form
+     */
+    T original();
+
+    /**
      * Yaml permission config.
      * Implementation note:
      * Yaml permission config allows {@link AdapterBasicPermission#WILDCARD} yaml sequence.In
      * yamls `*` sign can be quoted. Thus, we need to handle various quotes properly.
      * @since 1.2
      */
-    final class Yaml implements PermissionConfig {
+    final class Yaml implements PermissionConfig<YamlMapping> {
 
         /**
          * Yaml mapping to read permission from.
@@ -89,6 +97,11 @@ public interface PermissionConfig {
                 ).collect(Collectors.toSet());
             }
             return res;
+        }
+
+        @Override
+        public YamlMapping original() {
+            return this.yaml;
         }
 
         /**

--- a/src/main/java/com/artipie/security/perms/PermissionFactory.java
+++ b/src/main/java/com/artipie/security/perms/PermissionFactory.java
@@ -4,19 +4,19 @@
  */
 package com.artipie.security.perms;
 
-import java.security.Permission;
-import java.util.Collection;
+import java.security.PermissionCollection;
 
 /**
- * Permission factory to create permission instance.
+ * Permission factory to create permissions.
+ * @param <T> Permission collection implementation
  * @since 1.2
  */
-public interface PermissionFactory {
+public interface PermissionFactory<T extends PermissionCollection> {
 
     /**
-     * Create permission instance.
+     * Create permissions collection.
      * @param config Configuration
-     * @return Config
+     * @return Permission collection
      */
-    Collection<Permission> newPermission(PermissionConfig<?> config);
+    T newPermissions(PermissionConfig config);
 }

--- a/src/main/java/com/artipie/security/perms/PermissionFactory.java
+++ b/src/main/java/com/artipie/security/perms/PermissionFactory.java
@@ -5,6 +5,7 @@
 package com.artipie.security.perms;
 
 import java.security.Permission;
+import java.util.Collection;
 
 /**
  * Permission factory to create permission instance.
@@ -17,5 +18,5 @@ public interface PermissionFactory {
      * @param config Configuration
      * @return Config
      */
-    Permission newPermission(PermissionConfig config);
+    Collection<Permission> newPermission(PermissionConfig<?> config);
 }

--- a/src/main/java/com/artipie/security/perms/PermissionsLoader.java
+++ b/src/main/java/com/artipie/security/perms/PermissionsLoader.java
@@ -6,9 +6,8 @@ package com.artipie.security.perms;
 
 import com.artipie.ArtipieException;
 import com.artipie.asto.factory.FactoryLoader;
-import java.security.Permission;
+import java.security.PermissionCollection;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Map;
 
 /**
@@ -16,8 +15,8 @@ import java.util.Map;
  * @since 1.2
  */
 public final class PermissionsLoader extends
-    FactoryLoader<PermissionFactory, ArtipiePermissionFactory, PermissionConfig<?>,
-        Collection<Permission>> {
+    FactoryLoader<PermissionFactory<PermissionCollection>, ArtipiePermissionFactory,
+        PermissionConfig, PermissionCollection> {
 
     /**
      * Environment parameter to define packages to find permission factories.
@@ -51,12 +50,12 @@ public final class PermissionsLoader extends
     }
 
     @Override
-    public Collection<Permission> newObject(final String type, final PermissionConfig<?> config) {
-        final PermissionFactory factory = this.factories.get(type);
+    public PermissionCollection newObject(final String type, final PermissionConfig config) {
+        final PermissionFactory<?> factory = this.factories.get(type);
         if (factory == null) {
             throw new ArtipieException(String.format("Permission type %s is not found", type));
         }
-        return factory.newPermission(config);
+        return factory.newPermissions(config);
     }
 
     @Override

--- a/src/main/java/com/artipie/security/perms/PermissionsLoader.java
+++ b/src/main/java/com/artipie/security/perms/PermissionsLoader.java
@@ -9,6 +9,9 @@ import com.artipie.asto.factory.FactoryLoader;
 import java.security.PermissionCollection;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Load from the packages via reflection and instantiate permission factories object.
@@ -40,8 +43,8 @@ public final class PermissionsLoader extends
     }
 
     @Override
-    public String defPackage() {
-        return "com.artipie.security";
+    public Set<String> defPackages() {
+        return Stream.of("com.artipie.security", "com.artipie.docker").collect(Collectors.toSet());
     }
 
     @Override

--- a/src/main/java/com/artipie/security/perms/PermissionsLoader.java
+++ b/src/main/java/com/artipie/security/perms/PermissionsLoader.java
@@ -8,6 +8,7 @@ import com.artipie.ArtipieException;
 import com.artipie.asto.factory.FactoryLoader;
 import java.security.Permission;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Map;
 
 /**
@@ -15,7 +16,8 @@ import java.util.Map;
  * @since 1.2
  */
 public final class PermissionsLoader extends
-    FactoryLoader<PermissionFactory, ArtipiePermissionFactory, PermissionConfig, Permission> {
+    FactoryLoader<PermissionFactory, ArtipiePermissionFactory, PermissionConfig<?>,
+        Collection<Permission>> {
 
     /**
      * Environment parameter to define packages to find permission factories.
@@ -49,7 +51,7 @@ public final class PermissionsLoader extends
     }
 
     @Override
-    public Permission newObject(final String type, final PermissionConfig config) {
+    public Collection<Permission> newObject(final String type, final PermissionConfig<?> config) {
         final PermissionFactory factory = this.factories.get(type);
         if (factory == null) {
             throw new ArtipieException(String.format("Permission type %s is not found", type));

--- a/src/main/java/com/artipie/security/policy/CachedYamlPolicy.java
+++ b/src/main/java/com/artipie/security/policy/CachedYamlPolicy.java
@@ -266,11 +266,13 @@ public final class CachedYamlPolicy implements Policy<UserPermissions>, Cleanabl
                 .collect(Collectors.toSet())) {
                 final YamlMapping perms = all.yamlMapping(type);
                 if (perms == null || perms.keys().isEmpty()) {
-                    FACTORIES.newObject(type, CachedYamlPolicy.EMPTY_CONFIG)
-                        .elementsAsStream().forEach(res::add);
+                    Collections.list(
+                        FACTORIES.newObject(type, CachedYamlPolicy.EMPTY_CONFIG).elements()
+                    ).forEach(res::add);
                 } else {
-                    FACTORIES.newObject(type, new PermissionConfig.Yaml(perms))
-                        .elementsAsStream().forEach(res::add);
+                    Collections.list(
+                        FACTORIES.newObject(type, new PermissionConfig.Yaml(perms)).elements()
+                    ).forEach(res::add);
                 }
             }
         }

--- a/src/main/java/com/artipie/security/policy/CachedYamlPolicy.java
+++ b/src/main/java/com/artipie/security/policy/CachedYamlPolicy.java
@@ -96,7 +96,7 @@ public final class CachedYamlPolicy implements Policy<UserPermissions>, Cleanabl
     /**
      * Empty permissions' config.
      */
-    private static final PermissionConfig EMPTY_CONFIG =
+    private static final PermissionConfig<YamlMapping> EMPTY_CONFIG =
         new PermissionConfig.Yaml(Yaml.createYamlMappingBuilder().build());
 
     /**
@@ -266,10 +266,10 @@ public final class CachedYamlPolicy implements Policy<UserPermissions>, Cleanabl
                 .collect(Collectors.toSet())) {
                 final YamlMapping perms = all.yamlMapping(type);
                 if (perms == null || perms.keys().isEmpty()) {
-                    res.add(FACTORIES.newObject(type, CachedYamlPolicy.EMPTY_CONFIG));
+                    FACTORIES.newObject(type, CachedYamlPolicy.EMPTY_CONFIG).forEach(res::add);
                 } else {
                     perms.keys().stream().map(key -> key.asScalar().value()).forEach(
-                        key -> res.add(
+                        key ->
                             FACTORIES.newObject(
                                 type,
                                 new PermissionConfig.Yaml(
@@ -277,8 +277,7 @@ public final class CachedYamlPolicy implements Policy<UserPermissions>, Cleanabl
                                         key, perms.asMapping().yamlSequence(key)
                                     ).build()
                                 )
-                            )
-                        )
+                            ).forEach(res::add)
                     );
                 }
             }

--- a/src/main/java/com/artipie/security/policy/CachedYamlPolicy.java
+++ b/src/main/java/com/artipie/security/policy/CachedYamlPolicy.java
@@ -96,7 +96,7 @@ public final class CachedYamlPolicy implements Policy<UserPermissions>, Cleanabl
     /**
      * Empty permissions' config.
      */
-    private static final PermissionConfig<YamlMapping> EMPTY_CONFIG =
+    private static final PermissionConfig EMPTY_CONFIG =
         new PermissionConfig.Yaml(Yaml.createYamlMappingBuilder().build());
 
     /**
@@ -266,19 +266,11 @@ public final class CachedYamlPolicy implements Policy<UserPermissions>, Cleanabl
                 .collect(Collectors.toSet())) {
                 final YamlMapping perms = all.yamlMapping(type);
                 if (perms == null || perms.keys().isEmpty()) {
-                    FACTORIES.newObject(type, CachedYamlPolicy.EMPTY_CONFIG).forEach(res::add);
+                    FACTORIES.newObject(type, CachedYamlPolicy.EMPTY_CONFIG)
+                        .elementsAsStream().forEach(res::add);
                 } else {
-                    perms.keys().stream().map(key -> key.asScalar().value()).forEach(
-                        key ->
-                            FACTORIES.newObject(
-                                type,
-                                new PermissionConfig.Yaml(
-                                    Yaml.createYamlMappingBuilder().add(
-                                        key, perms.asMapping().yamlSequence(key)
-                                    ).build()
-                                )
-                            ).forEach(res::add)
-                    );
+                    FACTORIES.newObject(type, new PermissionConfig.Yaml(perms))
+                        .elementsAsStream().forEach(res::add);
                 }
             }
         }

--- a/src/main/java/com/artipie/security/policy/PoliciesLoader.java
+++ b/src/main/java/com/artipie/security/policy/PoliciesLoader.java
@@ -8,7 +8,9 @@ import com.artipie.ArtipieException;
 import com.artipie.asto.factory.Config;
 import com.artipie.asto.factory.FactoryLoader;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Load via reflection and create existing instances of {@link PolicyFactory} implementations.
@@ -39,8 +41,8 @@ public final class PoliciesLoader extends
     }
 
     @Override
-    public String defPackage() {
-        return "com.artipie.security";
+    public Set<String> defPackages() {
+        return Collections.singleton("com.artipie.security");
     }
 
     @Override

--- a/src/test/java/adapter/perms/docker/DockerPermsFactory.java
+++ b/src/test/java/adapter/perms/docker/DockerPermsFactory.java
@@ -8,18 +8,16 @@ import com.artipie.security.perms.ArtipiePermissionFactory;
 import com.artipie.security.perms.PermissionConfig;
 import com.artipie.security.perms.PermissionFactory;
 import java.security.AllPermission;
-import java.security.Permission;
-import java.util.Collection;
-import java.util.Collections;
+import java.security.PermissionCollection;
 
 /**
  * Test permission.
  * @since 1.2
  */
 @ArtipiePermissionFactory("docker-perm")
-public final class DockerPermsFactory implements PermissionFactory {
+public final class DockerPermsFactory implements PermissionFactory<PermissionCollection> {
     @Override
-    public Collection<Permission> newPermission(final PermissionConfig<?> config) {
-        return Collections.singleton(new AllPermission());
+    public PermissionCollection newPermissions(final PermissionConfig config) {
+        return new AllPermission().newPermissionCollection();
     }
 }

--- a/src/test/java/adapter/perms/docker/DockerPermsFactory.java
+++ b/src/test/java/adapter/perms/docker/DockerPermsFactory.java
@@ -9,6 +9,8 @@ import com.artipie.security.perms.PermissionConfig;
 import com.artipie.security.perms.PermissionFactory;
 import java.security.AllPermission;
 import java.security.Permission;
+import java.util.Collection;
+import java.util.Collections;
 
 /**
  * Test permission.
@@ -17,7 +19,7 @@ import java.security.Permission;
 @ArtipiePermissionFactory("docker-perm")
 public final class DockerPermsFactory implements PermissionFactory {
     @Override
-    public Permission newPermission(final PermissionConfig config) {
-        return new AllPermission();
+    public Collection<Permission> newPermission(final PermissionConfig<?> config) {
+        return Collections.singleton(new AllPermission());
     }
 }

--- a/src/test/java/adapter/perms/duplicate/DuplicatedDockerPermsFactory.java
+++ b/src/test/java/adapter/perms/duplicate/DuplicatedDockerPermsFactory.java
@@ -8,18 +8,16 @@ import com.artipie.security.perms.ArtipiePermissionFactory;
 import com.artipie.security.perms.PermissionConfig;
 import com.artipie.security.perms.PermissionFactory;
 import java.security.AllPermission;
-import java.security.Permission;
-import java.util.Collection;
-import java.util.Collections;
+import java.security.PermissionCollection;
 
 /**
  * Test permission.
  * @since 1.2
  */
 @ArtipiePermissionFactory("docker-perm")
-public final class DuplicatedDockerPermsFactory implements PermissionFactory {
+public final class DuplicatedDockerPermsFactory implements PermissionFactory<PermissionCollection> {
     @Override
-    public Collection<Permission> newPermission(final PermissionConfig<?> config) {
-        return Collections.singleton(new AllPermission());
+    public PermissionCollection newPermissions(final PermissionConfig config) {
+        return new AllPermission().newPermissionCollection();
     }
 }

--- a/src/test/java/adapter/perms/duplicate/DuplicatedDockerPermsFactory.java
+++ b/src/test/java/adapter/perms/duplicate/DuplicatedDockerPermsFactory.java
@@ -9,6 +9,8 @@ import com.artipie.security.perms.PermissionConfig;
 import com.artipie.security.perms.PermissionFactory;
 import java.security.AllPermission;
 import java.security.Permission;
+import java.util.Collection;
+import java.util.Collections;
 
 /**
  * Test permission.
@@ -17,7 +19,7 @@ import java.security.Permission;
 @ArtipiePermissionFactory("docker-perm")
 public final class DuplicatedDockerPermsFactory implements PermissionFactory {
     @Override
-    public Permission newPermission(final PermissionConfig config) {
-        return new AllPermission();
+    public Collection<Permission> newPermission(final PermissionConfig<?> config) {
+        return Collections.singleton(new AllPermission());
     }
 }

--- a/src/test/java/adapter/perms/maven/MavenPermsFactory.java
+++ b/src/test/java/adapter/perms/maven/MavenPermsFactory.java
@@ -8,18 +8,16 @@ import com.artipie.security.perms.ArtipiePermissionFactory;
 import com.artipie.security.perms.PermissionConfig;
 import com.artipie.security.perms.PermissionFactory;
 import java.security.AllPermission;
-import java.security.Permission;
-import java.util.Collection;
-import java.util.Collections;
+import java.security.PermissionCollection;
 
 /**
  * Test permission.
  * @since 1.2
  */
 @ArtipiePermissionFactory("maven-perm")
-public final class MavenPermsFactory implements PermissionFactory {
+public final class MavenPermsFactory implements PermissionFactory<PermissionCollection> {
     @Override
-    public Collection<Permission> newPermission(final PermissionConfig<?> config) {
-        return Collections.singleton(new AllPermission());
+    public PermissionCollection newPermissions(final PermissionConfig config) {
+        return new AllPermission().newPermissionCollection();
     }
 }

--- a/src/test/java/adapter/perms/maven/MavenPermsFactory.java
+++ b/src/test/java/adapter/perms/maven/MavenPermsFactory.java
@@ -9,6 +9,8 @@ import com.artipie.security.perms.PermissionConfig;
 import com.artipie.security.perms.PermissionFactory;
 import java.security.AllPermission;
 import java.security.Permission;
+import java.util.Collection;
+import java.util.Collections;
 
 /**
  * Test permission.
@@ -17,7 +19,7 @@ import java.security.Permission;
 @ArtipiePermissionFactory("maven-perm")
 public final class MavenPermsFactory implements PermissionFactory {
     @Override
-    public Permission newPermission(final PermissionConfig config) {
-        return new AllPermission();
+    public Collection<Permission> newPermission(final PermissionConfig<?> config) {
+        return Collections.singleton(new AllPermission());
     }
 }

--- a/src/test/java/com/artipie/security/perms/PermissionConfigYamlTest.java
+++ b/src/test/java/com/artipie/security/perms/PermissionConfigYamlTest.java
@@ -45,22 +45,6 @@ import org.junit.jupiter.api.Test;
 public class PermissionConfigYamlTest {
 
     @Test
-    void readsName() throws IOException {
-        MatcherAssert.assertThat(
-            new PermissionConfig.Yaml(
-                Yaml.createYamlInput(
-                    String.join(
-                        "\n",
-                        "maven-repo:",
-                        "  - read"
-                    )
-                ).readYamlMapping()
-            ).name(),
-            new IsEqual<>("maven-repo")
-        );
-    }
-
-    @Test
     void readsSequence() throws IOException {
         MatcherAssert.assertThat(
             new PermissionConfig.Yaml(
@@ -79,7 +63,7 @@ public class PermissionConfigYamlTest {
     }
 
     @Test
-    void readValueByKey() throws IOException {
+    void readSubConfigAndValueByKey() throws IOException {
         MatcherAssert.assertThat(
             new PermissionConfig.Yaml(
                 Yaml.createYamlInput(
@@ -90,31 +74,36 @@ public class PermissionConfigYamlTest {
                         "  key1: value2"
                     )
                 ).readYamlMapping()
-            ).value("key"),
+            ).config("some-repo").string("key"),
             new IsEqual<>("value")
         );
     }
 
     @Test
-    void returnsOriginalForm() throws IOException {
+    void returnsKeys() throws IOException {
         final YamlMapping yaml = Yaml.createYamlInput(
             String.join(
                 "\n",
                 "docker-repo:",
-                "  repository:",
-                "    my-alpine:",
-                "      - pull",
-                "    ubuntu-slim:",
-                "      - pull",
-                "      - push",
-                "  registry:",
-                "    base:",
-                "      - \"*\""
+                "  my-alpine:",
+                "    - pull",
+                "  ubuntu-slim:",
+                "    - pull",
+                "    - push",
+                "docker-local:",
+                "  my-alpine:",
+                "    - pull",
+                "  ubuntu-slim:",
+                "    - pull",
+                "    - push",
+                "docker-vasy:",
+                "  vasy-img:",
+                "    - pull"
             )
         ).readYamlMapping();
         MatcherAssert.assertThat(
-            new PermissionConfig.Yaml(yaml).original(),
-            new IsEqual<>(yaml)
+            new PermissionConfig.Yaml(yaml).keys(),
+            Matchers.contains("docker-repo", "docker-local", "docker-vasy")
         );
     }
 }

--- a/src/test/java/com/artipie/security/perms/PermissionConfigYamlTest.java
+++ b/src/test/java/com/artipie/security/perms/PermissionConfigYamlTest.java
@@ -5,6 +5,7 @@
 package com.artipie.security.perms;
 
 import com.amihaiemil.eoyaml.Yaml;
+import com.amihaiemil.eoyaml.YamlMapping;
 import java.io.IOException;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -91,6 +92,29 @@ public class PermissionConfigYamlTest {
                 ).readYamlMapping()
             ).value("key"),
             new IsEqual<>("value")
+        );
+    }
+
+    @Test
+    void returnsOriginalForm() throws IOException {
+        final YamlMapping yaml = Yaml.createYamlInput(
+            String.join(
+                "\n",
+                "docker-repo:",
+                "  repository:",
+                "    my-alpine:",
+                "      - pull",
+                "    ubuntu-slim:",
+                "      - pull",
+                "      - push",
+                "  registry:",
+                "    base:",
+                "      - \"*\""
+            )
+        ).readYamlMapping();
+        MatcherAssert.assertThat(
+            new PermissionConfig.Yaml(yaml).original(),
+            new IsEqual<>(yaml)
         );
     }
 }

--- a/src/test/java/com/artipie/security/perms/PermissionConfigYamlTest.java
+++ b/src/test/java/com/artipie/security/perms/PermissionConfigYamlTest.java
@@ -53,12 +53,12 @@ public class PermissionConfigYamlTest {
                         "\n",
                         "some-repo:",
                         "  - read",
-                        "  - write",
+                        "  - \"*\"",
                         "  - delete"
                     )
                 ).readYamlMapping()
             ).sequence("some-repo"),
-            Matchers.contains("read", "write", "delete")
+            Matchers.contains("read", "*", "delete")
         );
     }
 

--- a/src/test/java/com/artipie/security/perms/PermissionsTest.java
+++ b/src/test/java/com/artipie/security/perms/PermissionsTest.java
@@ -29,7 +29,7 @@ class PermissionsTest {
                         .add("my-repo", Yaml.createYamlSequenceBuilder().add("read").build())
                         .build()
                 )
-            ),
+            ).iterator().next(),
             new IsInstanceOf(AdapterBasicPermission.class)
         );
     }
@@ -40,7 +40,7 @@ class PermissionsTest {
             new PermissionsLoader().newObject(
                 "adapter_all_permission",
                 new PermissionConfig.Yaml(Yaml.createYamlMappingBuilder().build())
-            ),
+            ).iterator().next(),
             new IsInstanceOf(AllPermission.class)
         );
     }
@@ -80,7 +80,7 @@ class PermissionsTest {
             permissions.newObject(
                 "maven-perm",
                 new PermissionConfig.Yaml(Yaml.createYamlMappingBuilder().build())
-            ),
+            ).iterator().next(),
             new IsInstanceOf(AllPermission.class)
         );
         MatcherAssert.assertThat(
@@ -88,7 +88,7 @@ class PermissionsTest {
             permissions.newObject(
                 "docker-perm",
                 new PermissionConfig.Yaml(Yaml.createYamlMappingBuilder().build())
-            ),
+            ).iterator().next(),
             new IsInstanceOf(AllPermission.class)
         );
     }

--- a/src/test/java/com/artipie/security/perms/PermissionsTest.java
+++ b/src/test/java/com/artipie/security/perms/PermissionsTest.java
@@ -29,7 +29,7 @@ class PermissionsTest {
                         .add("my-repo", Yaml.createYamlSequenceBuilder().add("read").build())
                         .build()
                 )
-            ).iterator().next(),
+            ).elements().nextElement(),
             new IsInstanceOf(AdapterBasicPermission.class)
         );
     }
@@ -40,7 +40,7 @@ class PermissionsTest {
             new PermissionsLoader().newObject(
                 "adapter_all_permission",
                 new PermissionConfig.Yaml(Yaml.createYamlMappingBuilder().build())
-            ).iterator().next(),
+            ).elements().nextElement(),
             new IsInstanceOf(AllPermission.class)
         );
     }
@@ -80,7 +80,7 @@ class PermissionsTest {
             permissions.newObject(
                 "maven-perm",
                 new PermissionConfig.Yaml(Yaml.createYamlMappingBuilder().build())
-            ).iterator().next(),
+            ).elements().nextElement(),
             new IsInstanceOf(AllPermission.class)
         );
         MatcherAssert.assertThat(
@@ -88,7 +88,7 @@ class PermissionsTest {
             permissions.newObject(
                 "docker-perm",
                 new PermissionConfig.Yaml(Yaml.createYamlMappingBuilder().build())
-            ).iterator().next(),
+            ).elements().nextElement(),
             new IsInstanceOf(AllPermission.class)
         );
     }

--- a/src/test/java/com/artipie/security/policy/CachedYamlPolicyTest.java
+++ b/src/test/java/com/artipie/security/policy/CachedYamlPolicyTest.java
@@ -365,13 +365,13 @@ class CachedYamlPolicyTest {
             "\n",
             "permissions:",
             "  adapter_basic_permission:",
-            "    maven-repo:",
-            "      - read",
-            "      - write",
             "    python-repo:",
             "      - read",
             "    npm-repo:",
-            "      - read"
+            "      - read",
+            "    maven-repo:",
+            "      - read",
+            "      - write"
         ).getBytes(StandardCharsets.UTF_8);
     }
 


### PR DESCRIPTION
part of #501 

Docker permissions format includes resource (images name) and thus has more levels in yaml setting format:
```yaml
docker_repository_permission:
  my-docker:
    my-alpine: # resource (image) name
      - pull
    ubuntu-slim:
      - pull
      - push
  docker-global:
    *:
      - pull
docker_registry_permission:
  my-docker:
    - catalog
    - base
```

To parse such config and create permission we need to parse this yaml differently as yaml for `adapter_basic_permission`. In order to do so, I've made two changes:
- `PermissionFactory` now can return permissions collection
-  `PermissionConfig` permission config can return sub-config

In other words, all the changes are required as there can be only one `AdapterBasicPermission` for one repository, but in docker there can be several `DockerPermission` for one repository.
[Why there is permissions type can be "repository" or "registry"](https://docs.docker.com/registry/spec/auth/scope/).
